### PR TITLE
Get endEventKey through regular messagebus channel

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@essential-projects/messagebus_contracts": "^1.0.0",
     "@essential-projects/http_node": "^1.0.0",
     "@process-engine/consumer_api_contracts": "^0.3.0",
-    "@process-engine/process_engine_contracts": "^1.0.0",
+    "@process-engine/process_engine_contracts": "feature~provide_end_event_key_with_process_end_message",
     "addict-ioc": "^2.2.8",
     "async-middleware": "^1.2.1",
     "bluebird": "^3.4.7",

--- a/src/process_engine_adapter.ts
+++ b/src/process_engine_adapter.ts
@@ -1107,11 +1107,11 @@ export class ConsumerProcessEngineAdapter implements IConsumerApiService {
           return;
         }
 
-        if (message.data.action !== 'endEvent') {
+        if (!(message.data.event === 'end' || message.data.event === 'terminate')) {
           return;
         }
 
-        logger.verbose(`Reached EndEvent '${message.data.endEventKey}'`);
+        logger.info(`Reached EndEvent '${message.data.endEventKey}'`);
 
         if (message.data.endEventKey !== endEventEntity.key) {
           return;

--- a/src/process_engine_adapter.ts
+++ b/src/process_engine_adapter.ts
@@ -1106,7 +1106,13 @@ export class ConsumerProcessEngineAdapter implements IConsumerApiService {
           return;
         }
 
-        if (!(message.data.event === 'end' || message.data.event === 'terminate')) {
+        if (message.data.event === 'terminate') {
+          logger.warn(`Unexpected process termination through TerminationEndEvent '${message.data.endEventKey}'!`);
+
+          return reject(new InternalServerError(`The process was terminated through the '${message.data.endEventKey}' TerminationEndEvent!`));
+        }
+
+        if (message.data.event !== 'end') {
           return;
         }
 

--- a/src/process_engine_adapter.ts
+++ b/src/process_engine_adapter.ts
@@ -267,7 +267,6 @@ export class ConsumerProcessEngineAdapter implements IConsumerApiService {
     const startEventEntity: INodeDefEntity = await this._getStartEventEntity(executionContext, processModelKey, startEventKey);
     const endEventEntity: INodeDefEntity = await this._getEndEventEntity(executionContext, processModelKey, endEventKey);
 
-    // TODO: Return only after the given EndEvent was reached
     const processInstanceId: string = await this.processEngineService.createProcessInstance(executionContext, undefined, processModelKey);
 
     const correlationId: string =


### PR DESCRIPTION
Requires: https://github.com/process-engine/process_engine_contracts/pull/21 https://github.com/process-engine/process_engine/pull/65

## What did you change?

- Get endEventKey through regular messagebus channel
- Add support for the `terminate` state

## How can others test the changes?

Run the tests.
Be advised that there is no corresponding feature branch in the `consumer_api_meta` repository, because there was nothing to do there.
If you wish to test these changes using the tests, you'll have to manually set the version for the `@process-engine/process-engine` dependency to `feature~provide_end_event_key_with_process_end_message`.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
