### PR TITLE
Feature/rename start process to net specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@essential-projects/errors_ts": "^1.0.0",
     "@essential-projects/messagebus_contracts": "^1.0.0",
     "@essential-projects/http_node": "^1.0.0",
-    "@process-engine/consumer_api_contracts": "feature~rename_start_process_to_net_specs",
+    "@process-engine/consumer_api_contracts": "^0.5.0",
     "@process-engine/process_engine_contracts": "^3.2.0",
     "addict-ioc": "^2.2.8",
     "async-middleware": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@essential-projects/errors_ts": "^1.0.0",
     "@essential-projects/messagebus_contracts": "^1.0.0",
     "@essential-projects/http_node": "^1.0.0",
-    "@process-engine/consumer_api_contracts": "^0.3.0",
+    "@process-engine/consumer_api_contracts": "feature~rename_start_process_to_net_specs",
     "@process-engine/process_engine_contracts": "^3.2.0",
     "addict-ioc": "^2.2.8",
     "async-middleware": "^1.2.1",

--- a/src/consumer_api.ts
+++ b/src/consumer_api.ts
@@ -8,7 +8,7 @@ import {
   ProcessModelList,
   ProcessStartRequestPayload,
   ProcessStartResponsePayload,
-  ProcessStartReturnOnOptions,
+  StartCallbackType,
   UserTaskList,
   UserTaskResult,
 } from '@process-engine/consumer_api_contracts';
@@ -40,14 +40,14 @@ export class ConsumerApiService implements IConsumerApiService {
                                     processModelKey: string,
                                     startEventKey: string,
                                     payload: ProcessStartRequestPayload,
-                                    returnOn: ProcessStartReturnOnOptions = ProcessStartReturnOnOptions.onProcessInstanceStarted,
+                                    startCallbackType: StartCallbackType = StartCallbackType.CallbackOnProcessInstanceCreated,
                                   ): Promise<ProcessStartResponsePayload> {
 
-    if (!Object.values(ProcessStartReturnOnOptions).includes(returnOn)) {
-      throw new EssentialProjectErrors.BadRequestError(`${returnOn} is not a valid return option!`);
+    if (!Object.values(StartCallbackType).includes(startCallbackType)) {
+      throw new EssentialProjectErrors.BadRequestError(`${startCallbackType} is not a valid return option!`);
     }
 
-    return this.processEngineAdapter.startProcessInstance(context, processModelKey, startEventKey, payload, returnOn);
+    return this.processEngineAdapter.startProcessInstance(context, processModelKey, startEventKey, payload, startCallbackType);
   }
 
   public async startProcessInstanceAndAwaitEndEvent(context: ConsumerContext,

--- a/src/consumer_api.ts
+++ b/src/consumer_api.ts
@@ -36,27 +36,28 @@ export class ConsumerApiService implements IConsumerApiService {
     return this.processEngineAdapter.getProcessModelByKey(context, processModelKey);
   }
 
-  public async startProcess(context: ConsumerContext,
-                            processModelKey: string,
-                            startEventKey: string,
-                            payload: ProcessStartRequestPayload,
-                            returnOn: ProcessStartReturnOnOptions = ProcessStartReturnOnOptions.onProcessInstanceStarted,
-                          ): Promise<ProcessStartResponsePayload> {
+  public async startProcessInstance(context: ConsumerContext,
+                                    processModelKey: string,
+                                    startEventKey: string,
+                                    payload: ProcessStartRequestPayload,
+                                    returnOn: ProcessStartReturnOnOptions = ProcessStartReturnOnOptions.onProcessInstanceStarted,
+                                  ): Promise<ProcessStartResponsePayload> {
 
     if (!Object.values(ProcessStartReturnOnOptions).includes(returnOn)) {
       throw new EssentialProjectErrors.BadRequestError(`${returnOn} is not a valid return option!`);
     }
 
-    return this.processEngineAdapter.startProcess(context, processModelKey, startEventKey, payload, returnOn);
+    return this.processEngineAdapter.startProcessInstance(context, processModelKey, startEventKey, payload, returnOn);
   }
 
-  public async startProcessAndAwaitEndEvent(context: ConsumerContext,
-                                            processModelKey: string,
-                                            startEventKey: string,
-                                            endEventKey: string,
-                                            payload: ProcessStartRequestPayload): Promise<ProcessStartResponsePayload> {
+  public async startProcessInstanceAndAwaitEndEvent(context: ConsumerContext,
+                                                    processModelKey: string,
+                                                    startEventKey: string,
+                                                    endEventKey: string,
+                                                    payload: ProcessStartRequestPayload,
+                                                  ): Promise<ProcessStartResponsePayload> {
 
-    return this.processEngineAdapter.startProcessAndAwaitEndEvent(context, processModelKey, startEventKey, endEventKey, payload);
+    return this.processEngineAdapter.startProcessInstanceAndAwaitEndEvent(context, processModelKey, startEventKey, endEventKey, payload);
   }
 
   // Events

--- a/src/process_engine_adapter.ts
+++ b/src/process_engine_adapter.ts
@@ -669,10 +669,12 @@ export class ConsumerProcessEngineAdapter implements IConsumerApiService {
         continue;
       }
 
-      if (rootElement.laneSets) {
-        for (const laneSet of rootElement.laneSets) {
-          accessibleLanes = accessibleLanes.concat(await this._getLanesThatCanBeAccessed(identity, laneSet));
-        }
+      if (!rootElement.laneSets) {
+        continue;
+      }
+
+      for (const laneSet of rootElement.laneSets) {
+        accessibleLanes = accessibleLanes.concat(await this._getLanesThatCanBeAccessed(identity, laneSet));
       }
     }
 
@@ -727,12 +729,13 @@ export class ConsumerProcessEngineAdapter implements IConsumerApiService {
         continue;
       }
 
-      if (rootElement.laneSets) {
-        for (const laneSet of rootElement.laneSets) {
-          const closestLaneId: string = this._getClosestLaneIdToElement(laneSet, elementId);
-          if (closestLaneId !== undefined) {
-            return closestLaneId;
-          }
+      if (!rootElement.laneSets) {
+        continue;
+      }
+      for (const laneSet of rootElement.laneSets) {
+        const closestLaneId: string = this._getClosestLaneIdToElement(laneSet, elementId);
+        if (closestLaneId !== undefined) {
+          return closestLaneId;
         }
       }
     }

--- a/src/process_engine_adapter.ts
+++ b/src/process_engine_adapter.ts
@@ -10,7 +10,7 @@ import {
   ProcessModelList as ConsumerApiProcessModelList,
   ProcessStartRequestPayload,
   ProcessStartResponsePayload,
-  ProcessStartReturnOnOptions,
+  StartCallbackType,
   UserTask,
   UserTaskConfig,
   UserTaskFormField,
@@ -224,7 +224,7 @@ export class ConsumerProcessEngineAdapter implements IConsumerApiService {
                                     processModelKey: string,
                                     startEventKey: string,
                                     payload: ProcessStartRequestPayload,
-                                    returnOn: ProcessStartReturnOnOptions,
+                                    startCallbackType: StartCallbackType,
                                   ): Promise<ProcessStartResponsePayload> {
 
     const executionContext: ExecutionContext = await this._executionContextFromConsumerContext(context);
@@ -238,7 +238,7 @@ export class ConsumerProcessEngineAdapter implements IConsumerApiService {
 
     const processInstanceId: string = await this.processEngineService.createProcessInstance(executionContext, undefined, processModelKey);
 
-    if (returnOn === ProcessStartReturnOnOptions.onProcessInstanceStarted) {
+    if (startCallbackType === StartCallbackType.CallbackOnProcessInstanceCreated) {
       correlationId = await this._startProcessInstance(executionContext, processInstanceId, startEventEntity, payload);
     } else {
       correlationId = payload.correlation_id || uuid.v4();
@@ -732,6 +732,7 @@ export class ConsumerProcessEngineAdapter implements IConsumerApiService {
       if (!rootElement.laneSets) {
         continue;
       }
+
       for (const laneSet of rootElement.laneSets) {
         const closestLaneId: string = this._getClosestLaneIdToElement(laneSet, elementId);
         if (closestLaneId !== undefined) {

--- a/src/process_engine_adapter.ts
+++ b/src/process_engine_adapter.ts
@@ -220,11 +220,12 @@ export class ConsumerProcessEngineAdapter implements IConsumerApiService {
     return processModel;
   }
 
-  public async startProcess(context: ConsumerContext,
-                            processModelKey: string,
-                            startEventKey: string,
-                            payload: ProcessStartRequestPayload,
-                            returnOn: ProcessStartReturnOnOptions): Promise<ProcessStartResponsePayload> {
+  public async startProcessInstance(context: ConsumerContext,
+                                    processModelKey: string,
+                                    startEventKey: string,
+                                    payload: ProcessStartRequestPayload,
+                                    returnOn: ProcessStartReturnOnOptions,
+                                  ): Promise<ProcessStartResponsePayload> {
 
     const executionContext: ExecutionContext = await this._executionContextFromConsumerContext(context);
 
@@ -238,7 +239,7 @@ export class ConsumerProcessEngineAdapter implements IConsumerApiService {
     const processInstanceId: string = await this.processEngineService.createProcessInstance(executionContext, undefined, processModelKey);
 
     if (returnOn === ProcessStartReturnOnOptions.onProcessInstanceStarted) {
-      correlationId = await this.startProcessInstance(executionContext, processInstanceId, startEventEntity, payload);
+      correlationId = await this._startProcessInstance(executionContext, processInstanceId, startEventEntity, payload);
     } else {
       correlationId = payload.correlation_id || uuid.v4();
       this._correlations[correlationId] = processInstanceId;
@@ -253,11 +254,12 @@ export class ConsumerProcessEngineAdapter implements IConsumerApiService {
     return response;
   }
 
-  public async startProcessAndAwaitEndEvent(context: ConsumerContext,
-                                            processModelKey: string,
-                                            startEventKey: string,
-                                            endEventKey: string,
-                                            payload: ProcessStartRequestPayload): Promise<ProcessStartResponsePayload> {
+  public async startProcessInstanceAndAwaitEndEvent(context: ConsumerContext,
+                                                    processModelKey: string,
+                                                    startEventKey: string,
+                                                    endEventKey: string,
+                                                    payload: ProcessStartRequestPayload,
+                                                  ): Promise<ProcessStartResponsePayload> {
 
     const executionContext: ExecutionContext = await this._executionContextFromConsumerContext(context);
 
@@ -1026,10 +1028,10 @@ export class ConsumerProcessEngineAdapter implements IConsumerApiService {
   }
 
   // Manually implements "IProcessEntity.start()"
-  private async startProcessInstance(context: ExecutionContext,
-                                     processInstanceId: string,
-                                     startEventDef: INodeDefEntity,
-                                     payload: ProcessStartRequestPayload): Promise<string> {
+  private async _startProcessInstance(context: ExecutionContext,
+                                      processInstanceId: string,
+                                      startEventDef: INodeDefEntity,
+                                      payload: ProcessStartRequestPayload): Promise<string> {
 
     const processInstance: IProcessEntity = await this._getProcessInstanceById(context, processInstanceId);
 
@@ -1130,7 +1132,7 @@ export class ConsumerProcessEngineAdapter implements IConsumerApiService {
         processEndSubscription.cancel();
       });
 
-      correlationId = await this.startProcessInstance(executionContext, processInstanceId, startEventEntity, payload);
+      correlationId = await this._startProcessInstance(executionContext, processInstanceId, startEventEntity, payload);
     });
   }
 

--- a/src/process_engine_adapter.ts
+++ b/src/process_engine_adapter.ts
@@ -667,8 +667,10 @@ export class ConsumerProcessEngineAdapter implements IConsumerApiService {
         continue;
       }
 
-      for (const laneSet of rootElement.laneSets) {
-        accessibleLanes = accessibleLanes.concat(await this._getLanesThatCanBeAccessed(identity, laneSet));
+      if (rootElement.laneSets) {
+        for (const laneSet of rootElement.laneSets) {
+          accessibleLanes = accessibleLanes.concat(await this._getLanesThatCanBeAccessed(identity, laneSet));
+        }
       }
     }
 
@@ -723,10 +725,12 @@ export class ConsumerProcessEngineAdapter implements IConsumerApiService {
         continue;
       }
 
-      for (const laneSet of rootElement.laneSets) {
-        const closestLaneId: string = this._getClosestLaneIdToElement(laneSet, elementId);
-        if (closestLaneId !== undefined) {
-          return closestLaneId;
+      if (rootElement.laneSets) {
+        for (const laneSet of rootElement.laneSets) {
+          const closestLaneId: string = this._getClosestLaneIdToElement(laneSet, elementId);
+          if (closestLaneId !== undefined) {
+            return closestLaneId;
+          }
         }
       }
     }


### PR DESCRIPTION
## What did you change?

- Rename `startProcess` to `startProcessInstance`
- Rename `startProcessAndAwaitEndEvent` to `startProcessInstanceAndAwaitEndEvent`

The method signatures now match the .NET Consumer API definitions.

Also fixed and issue that caused and exception, when a process without lanes was read.

## How can others test the changes?

This is a cosmetic change, so everything should work as before.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
