### PR TITLE
Feature/add support for is executable flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/consumer_api_core",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "the api-package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
@@ -25,7 +25,7 @@
     "@essential-projects/messagebus_contracts": "^1.0.0",
     "@essential-projects/http_node": "^1.0.0",
     "@process-engine/consumer_api_contracts": "^0.5.0",
-    "@process-engine/process_engine_contracts": "^3.2.0",
+    "@process-engine/process_engine_contracts": "^4.0.0",
     "addict-ioc": "^2.2.8",
     "async-middleware": "^1.2.1",
     "bluebird": "^3.4.7",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@essential-projects/messagebus_contracts": "^1.0.0",
     "@essential-projects/http_node": "^1.0.0",
     "@process-engine/consumer_api_contracts": "^0.5.0",
-    "@process-engine/process_engine_contracts": "^4.0.0",
+    "@process-engine/process_engine_contracts": "^4.0.1",
     "addict-ioc": "^2.2.8",
     "async-middleware": "^1.2.1",
     "bluebird": "^3.4.7",


### PR DESCRIPTION
## What did you change?

Implement coverage for the `isExecutable` flag, which was added to the process definition:
- `getProcess` functions will not show any start events, if the process model is not marked as executable
- starting a process will cause an error, if the process is not marked as executable

## How can others test the changes?

Run the integrationtests in the `consumer_api_meta` repo. 

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [ ] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [ ] I've tested **all** changes included in this PR.
- [ ] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [ ] I've merged the `develop` branch into my branch before finishing this PR.
- [ ] I've **not added any other changes** than the ones described above.
- [ ] I've mentioned all **PRs, which relate to this one**
