### PR TITLE
Feature/merge process start functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@essential-projects/event_aggregator_contracts": "^2.0.0",
     "@essential-projects/messagebus_contracts": "^2.0.0",
     "@essential-projects/http_node": "^2.0.0",
-    "@process-engine/consumer_api_contracts": "^0.9.0",
+    "@process-engine/consumer_api_contracts": "feature~merge_process_start_functions",
     "@process-engine/process_engine_contracts": "^7.0.0",
     "addict-ioc": "^2.3.7",
     "async-middleware": "^1.2.1",

--- a/src/consumer_api.ts
+++ b/src/consumer_api.ts
@@ -50,7 +50,7 @@ export class ConsumerApiService implements IConsumerApiService {
     }
 
     if (startCallbackType === StartCallbackType.CallbackOnEndEventReached && !endEventKey) {
-      throw new EssentialProjectErrors.BadRequestError(`Must provide and EndEventKey, when using callback type 'CallbackOnEndEventReached'!`);
+      throw new EssentialProjectErrors.BadRequestError(`Must provide an EndEventKey, when using callback type 'CallbackOnEndEventReached'!`);
     }
 
     return this.processEngineAdapter.startProcessInstance(context, processModelKey, startEventKey, payload, startCallbackType, endEventKey);

--- a/src/consumer_api.ts
+++ b/src/consumer_api.ts
@@ -42,23 +42,18 @@ export class ConsumerApiService implements IConsumerApiService {
                                     startEventKey: string,
                                     payload: ProcessStartRequestPayload,
                                     startCallbackType: StartCallbackType = StartCallbackType.CallbackOnProcessInstanceCreated,
+                                    endEventKey?: string,
                                   ): Promise<ProcessStartResponsePayload> {
 
     if (!Object.values(StartCallbackType).includes(startCallbackType)) {
       throw new EssentialProjectErrors.BadRequestError(`${startCallbackType} is not a valid return option!`);
     }
 
-    return this.processEngineAdapter.startProcessInstance(context, processModelKey, startEventKey, payload, startCallbackType);
-  }
+    if (startCallbackType === StartCallbackType.CallbackOnEndEventReached && !endEventKey) {
+      throw new EssentialProjectErrors.BadRequestError(`Must provide and EndEventKey, when using callback type 'CallbackOnEndEventReached'!`);
+    }
 
-  public async startProcessInstanceAndAwaitEndEvent(context: ConsumerContext,
-                                                    processModelKey: string,
-                                                    startEventKey: string,
-                                                    endEventKey: string,
-                                                    payload: ProcessStartRequestPayload,
-                                                  ): Promise<ProcessStartResponsePayload> {
-
-    return this.processEngineAdapter.startProcessInstanceAndAwaitEndEvent(context, processModelKey, startEventKey, endEventKey, payload);
+    return this.processEngineAdapter.startProcessInstance(context, processModelKey, startEventKey, payload, startCallbackType, endEventKey);
   }
 
   public async getProcessResultForCorrelation(context: ConsumerContext,

--- a/src/process_engine_adapter/process_engine_adapter.ts
+++ b/src/process_engine_adapter/process_engine_adapter.ts
@@ -223,7 +223,7 @@ export class ConsumerApiProcessEngineAdapter implements IConsumerApiService {
                                     startEventKey: string,
                                     payload: ProcessStartRequestPayload,
                                     startCallbackType: StartCallbackType,
-                                    endEventKey: string,
+                                    endEventKey?: string,
                                   ): Promise<ProcessStartResponsePayload> {
 
     const executionContext: ExecutionContext = await this._createExecutionContextFromConsumerContext(context);


### PR DESCRIPTION
Closes #25 

## What did you change?

Merge the two public functions for starting process instances.

To keep functional impact at a minimum, this change was only applied to the ConsumerApiService, not the ProcessEngine adapter.

## How can others test the changes?

- Try using the `startProcessInstanceAndAwaitEndEvent` method and see that it is gone
- Use the `startProcessInstance` function for what was previously done with `startProcessInstanceAndAwaitEndEvent` and see that it works

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
