### PR TITLE
Implement access check for retrieving process instance results

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@essential-projects/event_aggregator_contracts": "^2.0.0",
     "@essential-projects/messagebus_contracts": "^2.0.0",
     "@essential-projects/http_node": "^2.0.0",
-    "@process-engine/consumer_api_contracts": "develop",
+    "@process-engine/consumer_api_contracts": "feature~add_end_event_keys_to_process_models",
     "@process-engine/process_engine_contracts": "^7.0.0",
     "addict-ioc": "^2.3.7",
     "async-middleware": "^1.2.1",


### PR DESCRIPTION
## What did you change?

Users can now only access the results of process instances that have reached an EndEvent to which they have sufficient access rights.

## How can others test the changes?

There are integrationtests which cover this.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
