### PR TITLE
Feature/remove old datastore implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
   "homepage": "https://github.com/process-engine/consumer_api#readme",
   "dependencies": {
     "@essential-projects/errors_ts": "^1.1.0",
-    "@essential-projects/event_aggregator_contracts": "^2.0.0",
+    "@essential-projects/event_aggregator_contracts": "feature~remove_old_datastore_implementation",
     "@essential-projects/iam_contracts": "^3.0.0",
     "@process-engine/consumer_api_contracts": "^0.12.1",
-    "@process-engine/process_engine_contracts": "^13.0.0",
+    "@process-engine/process_engine_contracts": "feature~remove_old_datastore_implementation",
     "addict-ioc": "^2.3.7",
     "async-middleware": "^1.2.1",
     "bluebird": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/consumer_api_core",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "the api-package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
## What did you change?

Update `event_aggregator_contracts` and `process_engine_contracts` packages, so that no old packages will get installed anymore as inherited dependencies.

## How can others test the changes?

Install the package and see that packages like `core_contracts` or `foundation` will no longer be installed as dependencies.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
