### PR TITLE
♻️ Make user task result optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@essential-projects/errors_ts": "^1.1.0",
     "@essential-projects/event_aggregator_contracts": "^3.0.0",
     "@essential-projects/iam_contracts": "^3.0.0",
-    "@process-engine/consumer_api_contracts": "^0.15.0",
+    "@process-engine/consumer_api_contracts": "^0.16.0",
     "@process-engine/process_engine_contracts": "^24.0.0",
     "addict-ioc": "^2.3.7",
     "async-middleware": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/consumer_api_core",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "description": "the api-package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/src/consumer_api_service.ts
+++ b/src/consumer_api_service.ts
@@ -376,15 +376,15 @@ export class ConsumerApiService implements IConsumerApiService {
       return {};
     }
 
-    const formFieldResultIsAnObject: boolean = finishedTask.formFields && typeof finishedTask.formFields === 'object';
+    const formFieldResultIsNotAnObject: boolean = !(finishedTask.formFields && typeof finishedTask.formFields === 'object');
 
-    if (!formFieldResultIsAnObject) {
-      throw new EssentialProjectErrors.BadRequestError('The UserTasks formFields is not an object.');
+    if (formFieldResultIsNotAnObject) {
+      throw new EssentialProjectErrors.BadRequestError('The UserTasks Form Fields is not contain an object.');
     }
 
-    const formFieldHasValues: boolean = formFieldResultIsAnObject && Object.keys(finishedTask.formFields).length > 0;
+    const formFieldHasNoValues: boolean = !(formFieldResultIsAnObject && Object.keys(finishedTask.formFields).length > 0);
 
-    if (!formFieldHasValues) {
+    if (formFieldHasNoValues) {
       return {};
     }
 

--- a/src/consumer_api_service.ts
+++ b/src/consumer_api_service.ts
@@ -273,12 +273,7 @@ export class ConsumerApiService implements IConsumerApiService {
       throw new EssentialProjectErrors.NotFoundError(errorMessage);
     }
 
-    let resultForProcessEngine: any = {};
-
-    const userTaskResultProvided: boolean = UserTaskResult !== undefined;
-    if (userTaskResultProvided) {
-      resultForProcessEngine = this._getUserTaskResultFromUserTaskConfig(userTaskResult);
-    }
+    const resultForProcessEngine: any = this._getUserTaskResultFromUserTaskConfig(userTaskResult);
 
     return new Promise<void>((resolve: Function, reject: Function): void => {
       this.eventAggregator.subscribeOnce(`/processengine/node/${userTask.id}/finished`, (event: any) => {
@@ -374,16 +369,22 @@ export class ConsumerApiService implements IConsumerApiService {
   }
 
   private _getUserTaskResultFromUserTaskConfig(finishedTask: UserTaskResult): any {
-    const userTaskIsNotAnObject: boolean = !finishedTask.formFields
-                                        || typeof finishedTask.formFields !== 'object'
-                                        || Array.isArray(finishedTask.formFields);
 
-    if (userTaskIsNotAnObject) {
+    const noResultsProvided: boolean = !finishedTask || !finishedTask.formFields;
+
+    if (noResultsProvided) {
+      return {};
+    }
+
+    const formFieldResultIsAnObject: boolean = finishedTask.formFields && typeof finishedTask.formFields === 'object';
+
+    if (!formFieldResultIsAnObject) {
       throw new EssentialProjectErrors.BadRequestError('The UserTasks formFields is not an object.');
     }
 
-    const noFormfieldsSubmitted: boolean = Object.keys(finishedTask.formFields).length === 0;
-    if (noFormfieldsSubmitted) {
+    const formFieldHasValues: boolean = formFieldResultIsAnObject && Object.keys(finishedTask.formFields).length > 0;
+
+    if (!formFieldHasValues) {
       return {};
     }
 

--- a/src/consumer_api_service.ts
+++ b/src/consumer_api_service.ts
@@ -382,7 +382,7 @@ export class ConsumerApiService implements IConsumerApiService {
       throw new EssentialProjectErrors.BadRequestError('The UserTasks Form Fields is not contain an object.');
     }
 
-    const formFieldHasNoValues: boolean = !(formFieldResultIsAnObject && Object.keys(finishedTask.formFields).length > 0);
+    const formFieldHasNoValues: boolean = !(formFieldResultIsNotAnObject && Object.keys(finishedTask.formFields).length > 0);
 
     if (formFieldHasNoValues) {
       return {};


### PR DESCRIPTION
**Changes:**

- Make `userTaskResult` optional, when finishing user tasks
- Refactor the user task result validation to make it easier to comprehend

Issues: https://github.com/process-engine/process_engine_runtime/issues/18

PR: #53

## How can others test the changes?

Try to finish a user task without providing form field results.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).

## Example

<details>
<summary>
:warning: Before merging please click here to expand and follow the guide.
</summary>
<br>

Please use `:twisted_rightwards_arrows:` at the beginning of your merge commit title.

Example 1:

<pre>
<code>
:twisted_rightwards_arrows: :bug: Fix Wrong Text Decoration at ...
</code>
</pre>

To get your commit message, just copy the first part of this pull request.

Example 2:
<pre>
<code>
**Changes:**

- Fixes Wrong Text Decoration at ...
- Fixes some typos
- ...

**Issues:**

Closes #NumberOfFixedIssue

PR: #NumberOfThisPR
</code>
</pre>
</details>

## Emojis

<details>
<summary>
Expand for a list of most used Emojis.
</summary>
<br>

Please prefix your commit messages with an Emoji.

Ref: https://gitmoji.carloscuesta.me/

| Description              | Glyphe               | Emoji  |
|--------------------------|----------------------|--------|
| Bugfix                   | `:bug:`              | 🐛     |
| Configuration releated   | `:wrench:`           | 🔧     |
| Cosmetic                 | `:lipstick:`         | 💄     |
| Dependencies Downgrade   | `:arrow_down:`       | ⬇️     |
| Dependencies Upgrade     | `:arrow_up:`         | ⬆️     |
| Formatting               | `:art:`              | 🎨     |
| Improving Performance    | `:zap:`              | ⚡️     |
| Initial commit           | `:tada:`             | 🎉     |
| Linter                   | `:rotating_light:`   | 🚨     |
| Miscellaneous            | `:package:`          | 📦     |
| New Feature              | `:sparkles:`         | ✨     |
| Refactoring Code         | `:recycle:`          | ♻️     |
| Releasing / Version tags | `:bookmark:`         | 🔖     |
| Removing Stuff           | `:fire:`             | 🔥     |
| Tests                    | `:white_check_mark:` | ✅     |
| Work In Progress (WIP)   | `:construction:`     | 🚧     |

</details>
