### PR TITLE
🐛 Filter non-UserTasks before converting suspended FlowNodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@essential-projects/event_aggregator_contracts": "^3.0.0",
     "@essential-projects/iam_contracts": "^3.0.0",
     "@process-engine/consumer_api_contracts": "^0.16.1",
-    "@process-engine/process_engine_contracts": "^24.0.0",
+    "@process-engine/process_engine_contracts": "^25.0.0",
     "addict-ioc": "^2.3.7",
     "async-middleware": "^1.2.1",
     "bluebird": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/consumer_api_core",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "the api-package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
**Changes:**

Enhances the UserTask Converter with a filter to ensure that only suspended UserTasks get passed through the Converter.


**Issues:**

Closes #59 

PR: #60

## How can others test the changes?

See reproduction steps of the issue and note that making the request will no longer lead to an error.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).

## Example

<details>
<summary>
:warning: Before merging please click here to expand and follow the guide.
</summary>
<br>

Please use `:twisted_rightwards_arrows:` at the beginning of your merge commit title.

Example 1:

<pre>
<code>
:twisted_rightwards_arrows: :bug: Fix Wrong Text Decoration at ...
</code>
</pre>

To get your commit message, just copy the first part of this pull request.

Example 2:
<pre>
<code>
**Changes:**

- Fixes Wrong Text Decoration at ...
- Fixes some typos
- ...

**Issues:**

Closes #NumberOfFixedIssue

PR: #NumberOfThisPR
</code>
</pre>
</details>

## Emojis

<details>
<summary>
Expand for a list of most used Emojis.
</summary>
<br>

Please prefix your commit messages with an Emoji.

Ref: https://gitmoji.carloscuesta.me/

| Description              | Glyphe               | Emoji  |
|--------------------------|----------------------|--------|
| Bugfix                   | `:bug:`              | 🐛     |
| Configuration releated   | `:wrench:`           | 🔧     |
| Cosmetic                 | `:lipstick:`         | 💄     |
| Dependencies Downgrade   | `:arrow_down:`       | ⬇️     |
| Dependencies Upgrade     | `:arrow_up:`         | ⬆️     |
| Formatting               | `:art:`              | 🎨     |
| Improving Performance    | `:zap:`              | ⚡️     |
| Initial commit           | `:tada:`             | 🎉     |
| Linter                   | `:rotating_light:`   | 🚨     |
| Miscellaneous            | `:package:`          | 📦     |
| New Feature              | `:sparkles:`         | ✨     |
| Refactoring Code         | `:recycle:`          | ♻️     |
| Releasing / Version tags | `:bookmark:`         | 🔖     |
| Removing Stuff           | `:fire:`             | 🔥     |
| Tests                    | `:white_check_mark:` | ✅     |
| Work In Progress (WIP)   | `:construction:`     | 🚧     |

</details>
