### PR TITLE
♻️ Refactor socket io handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "~1.4.0",
     "@essential-projects/event_aggregator_contracts": "~4.0.0",
-    "@essential-projects/iam_contracts": "feature~refactor_socket_io_handling",
+    "@essential-projects/iam_contracts": "~3.4.0",
     "@process-engine/consumer_api_contracts": "feature~refactor_socket_io_handling",
     "@process-engine/process_engine_contracts": "~36.5.0",
     "bluebird": "~3.5.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@essential-projects/errors_ts": "~1.4.0",
     "@essential-projects/event_aggregator_contracts": "~4.0.0",
     "@essential-projects/iam_contracts": "~3.4.0",
-    "@process-engine/consumer_api_contracts": "feature~refactor_socket_io_handling",
+    "@process-engine/consumer_api_contracts": "~4.0.0",
     "@process-engine/process_engine_contracts": "~36.5.0",
     "bluebird": "~3.5.2",
     "bluebird-global": "~1.0.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@process-engine/process_engine_contracts": "~36.5.0",
     "bluebird": "~3.5.2",
     "bluebird-global": "~1.0.1",
-    "jsonwebtoken": "~8.4.0",
     "loggerhythm": "^3.0.3",
     "uuid": "~3.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/consumer_api_core",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "the api-package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "@essential-projects/errors_ts": "~1.4.0",
     "@essential-projects/event_aggregator_contracts": "~4.0.0",
-    "@essential-projects/iam_contracts": "~3.3.0",
-    "@process-engine/consumer_api_contracts": "~3.0.0",
+    "@essential-projects/iam_contracts": "feature~refactor_socket_io_handling",
+    "@process-engine/consumer_api_contracts": "feature~refactor_socket_io_handling",
     "@process-engine/process_engine_contracts": "~36.5.0",
     "bluebird": "~3.5.2",
     "bluebird-global": "~1.0.1",

--- a/src/adapters/notification_adapter.ts
+++ b/src/adapters/notification_adapter.ts
@@ -1,6 +1,6 @@
 import * as jsonwebtoken from 'jsonwebtoken';
 
-import {IEventAggregator} from '@essential-projects/event_aggregator_contracts';
+import {IEventAggregator, Subscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity, TokenBody} from '@essential-projects/iam_contracts';
 import {Messages} from '@process-engine/consumer_api_contracts';
 
@@ -12,9 +12,10 @@ export class NotificationAdapter {
     this._eventAggregator = eventAggregator;
   }
 
-  public onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): void {
+  public onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Subscription {
     const eventName: string = Messages.EventAggregatorSettings.messagePaths.userTaskReached;
-    this
+
+    return this
       ._eventAggregator
       .subscribe(eventName, (message: Messages.Internal.SystemEvents.UserTaskReachedMessage) => {
         const sanitizedMessage: Messages.Public.SystemEvents.UserTaskReachedMessage = this._sanitizeInternalMessageForPublicNotification(message);
@@ -23,9 +24,10 @@ export class NotificationAdapter {
       });
   }
 
-  public onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): void {
+  public onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Subscription {
     const eventName: string = Messages.EventAggregatorSettings.messagePaths.userTaskFinished;
-    this
+
+    return this
       ._eventAggregator
       .subscribe(eventName, (message: Messages.Internal.SystemEvents.UserTaskFinishedMessage) => {
         const sanitizedMessage: Messages.Public.SystemEvents.UserTaskFinishedMessage = this._sanitizeInternalMessageForPublicNotification(message);
@@ -34,9 +36,10 @@ export class NotificationAdapter {
       });
   }
 
-  public onUserTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): void {
+  public onUserTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Subscription {
     const eventName: string = Messages.EventAggregatorSettings.messagePaths.userTaskReached;
-    this
+
+    return this
       ._eventAggregator
       .subscribe(eventName, (message: Messages.Internal.SystemEvents.UserTaskReachedMessage) => {
 
@@ -49,9 +52,10 @@ export class NotificationAdapter {
       });
   }
 
-  public onUserTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): void {
+  public onUserTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Subscription {
     const eventName: string = Messages.EventAggregatorSettings.messagePaths.userTaskFinished;
-    this
+
+    return this
       ._eventAggregator
       .subscribe(eventName, (message: Messages.Internal.SystemEvents.UserTaskFinishedMessage) => {
 
@@ -64,9 +68,10 @@ export class NotificationAdapter {
       });
   }
 
-  public onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): void {
+  public onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Subscription {
     const eventName: string = Messages.EventAggregatorSettings.messagePaths.manualTaskReached;
-    this
+
+    return this
       ._eventAggregator
       .subscribe(eventName, (message: Messages.Internal.SystemEvents.ManualTaskReachedMessage) => {
         const sanitizedMessage: Messages.Public.SystemEvents.ManualTaskReachedMessage = this._sanitizeInternalMessageForPublicNotification(message);
@@ -74,9 +79,10 @@ export class NotificationAdapter {
       });
   }
 
-  public onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): void {
+  public onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Subscription {
     const eventName: string = Messages.EventAggregatorSettings.messagePaths.manualTaskFinished;
-    this
+
+    return this
       ._eventAggregator
       .subscribe(eventName, (message: Messages.Internal.SystemEvents.ManualTaskFinishedMessage) => {
         const sanitizedMessage: Messages.Public.SystemEvents.ManualTaskFinishedMessage = this._sanitizeInternalMessageForPublicNotification(message);
@@ -84,9 +90,10 @@ export class NotificationAdapter {
       });
   }
 
-  public onManualTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): void {
+  public onManualTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Subscription {
     const eventName: string = Messages.EventAggregatorSettings.messagePaths.manualTaskReached;
-    this
+
+    return this
       ._eventAggregator
       .subscribe(eventName, (message: Messages.Internal.SystemEvents.ManualTaskReachedMessage) => {
 
@@ -98,9 +105,10 @@ export class NotificationAdapter {
       });
   }
 
-  public onManualTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): void {
+  public onManualTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Subscription {
     const eventName: string = Messages.EventAggregatorSettings.messagePaths.manualTaskFinished;
-    this
+
+    return this
       ._eventAggregator
       .subscribe(eventName, (message: Messages.Internal.SystemEvents.ManualTaskFinishedMessage) => {
 
@@ -112,9 +120,10 @@ export class NotificationAdapter {
       });
   }
 
-  public onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): void {
+  public onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): Subscription {
     const eventName: string = Messages.EventAggregatorSettings.messagePaths.processStarted;
-    this
+
+    return this
       ._eventAggregator
       .subscribe(eventName, (message: Messages.Internal.SystemEvents.ProcessStartedMessage) => {
         const sanitizedMessage: Messages.Public.SystemEvents.ProcessStartedMessage = this._sanitizeInternalMessageForPublicNotification(message);
@@ -126,10 +135,11 @@ export class NotificationAdapter {
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnProcessStartedCallback,
     processModelId: string,
-  ): void {
+  ): Subscription {
     const processWithIdStartedMessageEventName: string = Messages.EventAggregatorSettings.messagePaths.processInstanceStarted
         .replace(Messages.EventAggregatorSettings.messageParams.processModelId, processModelId);
-    this
+
+    return this
       ._eventAggregator
       .subscribe(processWithIdStartedMessageEventName, (message: Messages.Internal.SystemEvents.ProcessStartedMessage) => {
         const sanitizedMessage: Messages.Public.SystemEvents.ProcessStartedMessage = this._sanitizeInternalMessageForPublicNotification(message);
@@ -137,9 +147,10 @@ export class NotificationAdapter {
       });
   }
 
-  public onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): void {
+  public onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): Subscription {
     const eventName: string = Messages.EventAggregatorSettings.messagePaths.processEnded;
-    this
+
+    return this
       ._eventAggregator
       .subscribe(eventName, (message: Messages.Internal.BpmnEvents.EndEventReachedMessage) => {
         const sanitizedMessage: Messages.Public.BpmnEvents.EndEventReachedMessage = this._sanitizeInternalMessageForPublicNotification(message);
@@ -147,9 +158,10 @@ export class NotificationAdapter {
       });
   }
 
-  public onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): void {
+  public onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): Subscription {
     const eventName: string = Messages.EventAggregatorSettings.messagePaths.processTerminated;
-    this
+
+    return this
       ._eventAggregator
       .subscribe(eventName, (message: Messages.Internal.BpmnEvents.TerminateEndEventReachedMessage) => {
         const sanitizedMessage: Messages.Public.BpmnEvents.TerminateEndEventReachedMessage =

--- a/src/adapters/notification_adapter.ts
+++ b/src/adapters/notification_adapter.ts
@@ -169,15 +169,20 @@ export class NotificationAdapter {
     subscribeOnce: boolean,
   ): Subscription {
 
-    const processWithIdStartedMessageEventName: string = Messages.EventAggregatorSettings.messagePaths.processInstanceStarted
-        .replace(Messages.EventAggregatorSettings.messageParams.processModelId, processModelId);
+    const eventName: string = Messages.EventAggregatorSettings.messagePaths.processStarted;
 
     const sanitationCallback: EventReceivedCallback = (message: Messages.Internal.SystemEvents.ProcessStartedMessage): void => {
+
+      const processModelIdsDoNotMatch: boolean = message.processModelId !== processModelId;
+      if (processModelIdsDoNotMatch) {
+        return;
+      }
+
       const sanitizedMessage: Messages.Public.SystemEvents.ProcessStartedMessage = this._sanitizeInternalMessageForPublicNotification(message);
       callback(sanitizedMessage);
     };
 
-    return this._createSubscription(processWithIdStartedMessageEventName, sanitationCallback, subscribeOnce);
+    return this._createSubscription(eventName, sanitationCallback, subscribeOnce);
   }
 
   public onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback, subscribeOnce: boolean): Subscription {

--- a/src/adapters/notification_adapter.ts
+++ b/src/adapters/notification_adapter.ts
@@ -170,6 +170,10 @@ export class NotificationAdapter {
       });
   }
 
+  public removeSubscription(identity: IIdentity, subscription: Subscription): void {
+    this._eventAggregator.unsubscribe(subscription);
+  }
+
   private _checkIfIdentityUserIDsMatch(identityA: IIdentity, identityB: IIdentity): boolean {
 
     const decodedRequestingIdentity: TokenBody = <TokenBody> jsonwebtoken.decode(identityA.token);

--- a/src/adapters/notification_adapter.ts
+++ b/src/adapters/notification_adapter.ts
@@ -12,36 +12,30 @@ export class NotificationAdapter {
     this._eventAggregator = eventAggregator;
   }
 
-  public onUserTaskWaiting(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
-    subscribeOnce: boolean,
-  ): Subscription {
+  public onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback, subscribeOnce: boolean): Subscription {
 
     const eventName: string = Messages.EventAggregatorSettings.messagePaths.userTaskReached;
 
-    const attachResultCallback: EventReceivedCallback = (message: Messages.Internal.SystemEvents.UserTaskFinishedMessage): void => {
-      message.userTaskResult = message.userTaskResult;
-      callback(message);
+    const sanitationCallback: EventReceivedCallback = (message: Messages.Internal.SystemEvents.UserTaskReachedMessage): void => {
+      const sanitizedMessage: Messages.Public.SystemEvents.UserTaskReachedMessage = this._sanitizeInternalMessageForPublicNotification(message);
+      sanitizedMessage.userTaskResult = message.userTaskResult;
+      callback(sanitizedMessage);
     };
 
-    return this._createSubscription(eventName, attachResultCallback, subscribeOnce);
+    return this._createSubscription(eventName, sanitationCallback, subscribeOnce);
   }
 
-  public onUserTaskFinished(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
-    subscribeOnce: boolean,
-  ): Subscription {
+  public onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback, subscribeOnce: boolean): Subscription {
 
     const eventName: string = Messages.EventAggregatorSettings.messagePaths.userTaskFinished;
 
-    const attachResultCallback: EventReceivedCallback = (message: Messages.Internal.SystemEvents.UserTaskFinishedMessage): void => {
-      message.userTaskResult = message.userTaskResult;
-      callback(message);
+    const sanitationCallback: EventReceivedCallback = (message: Messages.Internal.SystemEvents.UserTaskFinishedMessage): void => {
+      const sanitizedMessage: Messages.Public.SystemEvents.UserTaskFinishedMessage = this._sanitizeInternalMessageForPublicNotification(message);
+      sanitizedMessage.userTaskResult = message.userTaskResult;
+      callback(sanitizedMessage);
     };
 
-    return this._createSubscription(eventName, attachResultCallback, subscribeOnce);
+    return this._createSubscription(eventName, sanitationCallback, subscribeOnce);
   }
 
   public onUserTaskForIdentityWaiting(
@@ -52,16 +46,17 @@ export class NotificationAdapter {
 
     const eventName: string = Messages.EventAggregatorSettings.messagePaths.userTaskReached;
 
-    const identityCheckCallback: EventReceivedCallback = (message: Messages.Internal.SystemEvents.UserTaskReachedMessage): void => {
+    const sanitationCallback: EventReceivedCallback = (message: Messages.Internal.SystemEvents.UserTaskReachedMessage): void => {
 
       const identitiesMatch: boolean = this._checkIfIdentityUserIDsMatch(identity, message.processInstanceOwner);
       if (identitiesMatch) {
-        message.userTaskResult = message.userTaskResult;
-        callback(message);
+        const sanitizedMessage: Messages.Public.SystemEvents.UserTaskReachedMessage = this._sanitizeInternalMessageForPublicNotification(message);
+        sanitizedMessage.userTaskResult = message.userTaskResult;
+        callback(sanitizedMessage);
       }
     };
 
-    return this._createSubscription(eventName, identityCheckCallback, subscribeOnce);
+    return this._createSubscription(eventName, sanitationCallback, subscribeOnce);
   }
 
   public onUserTaskForIdentityFinished(
@@ -72,16 +67,17 @@ export class NotificationAdapter {
 
     const eventName: string = Messages.EventAggregatorSettings.messagePaths.userTaskFinished;
 
-    const identityCheckCallback: EventReceivedCallback = (message: Messages.Internal.SystemEvents.UserTaskFinishedMessage): void => {
+    const sanitationCallback: EventReceivedCallback = (message: Messages.Internal.SystemEvents.UserTaskFinishedMessage): void => {
 
       const identitiesMatch: boolean = this._checkIfIdentityUserIDsMatch(identity, message.processInstanceOwner);
       if (identitiesMatch) {
-        message.userTaskResult = message.userTaskResult;
-        callback(message);
+        const sanitizedMessage: Messages.Public.SystemEvents.UserTaskFinishedMessage = this._sanitizeInternalMessageForPublicNotification(message);
+        sanitizedMessage.userTaskResult = message.userTaskResult;
+        callback(sanitizedMessage);
       }
     };
 
-    return this._createSubscription(eventName, identityCheckCallback, subscribeOnce);
+    return this._createSubscription(eventName, sanitationCallback, subscribeOnce);
   }
 
   public onManualTaskWaiting(
@@ -92,7 +88,12 @@ export class NotificationAdapter {
 
     const eventName: string = Messages.EventAggregatorSettings.messagePaths.manualTaskReached;
 
-    return this._createSubscription(eventName, callback, subscribeOnce);
+    const sanitationCallback: EventReceivedCallback = (message: Messages.Internal.SystemEvents.ManualTaskReachedMessage): void => {
+      const sanitizedMessage: Messages.Public.SystemEvents.ManualTaskReachedMessage = this._sanitizeInternalMessageForPublicNotification(message);
+      callback(sanitizedMessage);
+    };
+
+    return this._createSubscription(eventName, sanitationCallback, subscribeOnce);
   }
 
   public onManualTaskFinished(
@@ -103,7 +104,12 @@ export class NotificationAdapter {
 
     const eventName: string = Messages.EventAggregatorSettings.messagePaths.manualTaskFinished;
 
-    return this._createSubscription(eventName, callback, subscribeOnce);
+    const sanitationCallback: EventReceivedCallback = (message: Messages.Internal.SystemEvents.ManualTaskFinishedMessage): void => {
+      const sanitizedMessage: Messages.Public.SystemEvents.ManualTaskFinishedMessage = this._sanitizeInternalMessageForPublicNotification(message);
+      callback(sanitizedMessage);
+    };
+
+    return this._createSubscription(eventName, sanitationCallback, subscribeOnce);
   }
 
   public onManualTaskForIdentityWaiting(
@@ -114,15 +120,16 @@ export class NotificationAdapter {
 
     const eventName: string = Messages.EventAggregatorSettings.messagePaths.manualTaskReached;
 
-    const identityCheckCallback: EventReceivedCallback = (message: Messages.Internal.SystemEvents.ManualTaskReachedMessage): void => {
+    const sanitationCallback: EventReceivedCallback = (message: Messages.Internal.SystemEvents.ManualTaskReachedMessage): void => {
 
       const identitiesMatch: boolean = this._checkIfIdentityUserIDsMatch(identity, message.processInstanceOwner);
       if (identitiesMatch) {
-        callback(message);
+        const sanitizedMessage: Messages.Public.SystemEvents.ManualTaskReachedMessage = this._sanitizeInternalMessageForPublicNotification(message);
+        callback(sanitizedMessage);
       }
     };
 
-    return this._createSubscription(eventName, identityCheckCallback, subscribeOnce);
+    return this._createSubscription(eventName, sanitationCallback, subscribeOnce);
   }
 
   public onManualTaskForIdentityFinished(
@@ -133,26 +140,28 @@ export class NotificationAdapter {
 
     const eventName: string = Messages.EventAggregatorSettings.messagePaths.manualTaskFinished;
 
-    const identityCheckCallback: EventReceivedCallback = (message: Messages.Internal.SystemEvents.ManualTaskFinishedMessage): void => {
+    const sanitationCallback: EventReceivedCallback = (message: Messages.Internal.SystemEvents.ManualTaskFinishedMessage): void => {
 
       const identitiesMatch: boolean = this._checkIfIdentityUserIDsMatch(identity, message.processInstanceOwner);
       if (identitiesMatch) {
-        callback(message);
+        const sanitizedMessage: Messages.Public.SystemEvents.ManualTaskReachedMessage = this._sanitizeInternalMessageForPublicNotification(message);
+        callback(sanitizedMessage);
       }
     };
 
-    return this._createSubscription(eventName, identityCheckCallback, subscribeOnce);
+    return this._createSubscription(eventName, sanitationCallback, subscribeOnce);
   }
 
-  public onProcessStarted(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnProcessStartedCallback,
-    subscribeOnce: boolean,
-  ): Subscription {
+  public onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback, subscribeOnce: boolean): Subscription {
 
     const eventName: string = Messages.EventAggregatorSettings.messagePaths.processStarted;
 
-    return this._createSubscription(eventName, callback, subscribeOnce);
+    const sanitationCallback: EventReceivedCallback = (message: Messages.Internal.SystemEvents.ProcessStartedMessage): void => {
+      const sanitizedMessage: Messages.Public.SystemEvents.ProcessStartedMessage = this._sanitizeInternalMessageForPublicNotification(message);
+      callback(sanitizedMessage);
+    };
+
+    return this._createSubscription(eventName, sanitationCallback, subscribeOnce);
   }
 
   public onProcessWithProcessModelIdStarted(
@@ -163,20 +172,26 @@ export class NotificationAdapter {
   ): Subscription {
 
     const processWithIdStartedMessageEventName: string = Messages.EventAggregatorSettings.messagePaths.processInstanceStarted
-      .replace(Messages.EventAggregatorSettings.messageParams.processModelId, processModelId);
+        .replace(Messages.EventAggregatorSettings.messageParams.processModelId, processModelId);
 
-    return this._createSubscription(processWithIdStartedMessageEventName, callback, subscribeOnce);
+    const sanitationCallback: EventReceivedCallback = (message: Messages.Internal.SystemEvents.ProcessStartedMessage): void => {
+      const sanitizedMessage: Messages.Public.SystemEvents.ProcessStartedMessage = this._sanitizeInternalMessageForPublicNotification(message);
+      callback(sanitizedMessage);
+    };
+
+    return this._createSubscription(processWithIdStartedMessageEventName, sanitationCallback, subscribeOnce);
   }
 
-  public onProcessEnded(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnProcessEndedCallback,
-    subscribeOnce: boolean,
-  ): Subscription {
+  public onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback, subscribeOnce: boolean): Subscription {
 
     const eventName: string = Messages.EventAggregatorSettings.messagePaths.processEnded;
 
-    return this._createSubscription(eventName, callback, subscribeOnce);
+    const sanitationCallback: EventReceivedCallback = (message: Messages.Internal.BpmnEvents.EndEventReachedMessage): void => {
+      const sanitizedMessage: Messages.Public.BpmnEvents.EndEventReachedMessage = this._sanitizeInternalMessageForPublicNotification(message);
+      callback(sanitizedMessage);
+    };
+
+    return this._createSubscription(eventName, sanitationCallback, subscribeOnce);
   }
 
   public onProcessTerminated(
@@ -187,26 +202,26 @@ export class NotificationAdapter {
 
     const eventName: string = Messages.EventAggregatorSettings.messagePaths.processTerminated;
 
-    return this._createSubscription(eventName, callback, subscribeOnce);
-  }
-
-  public removeSubscription(identity: IIdentity, subscription: Subscription): void {
-    this._eventAggregator.unsubscribe(subscription);
-  }
-
-  private _createSubscription(eventName: string, callback: EventReceivedCallback, subscribeOnce: boolean): Subscription {
-
-    const performSanitationCallback: EventReceivedCallback = (message: Messages.Internal.BaseInternalEventMessage): void => {
+    const sanitationCallback: EventReceivedCallback = (message: Messages.Internal.BpmnEvents.TerminateEndEventReachedMessage): void => {
       const sanitizedMessage: Messages.Public.BpmnEvents.TerminateEndEventReachedMessage =
         this._sanitizeInternalMessageForPublicNotification(message);
       callback(sanitizedMessage);
     };
 
+    return this._createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  public removeSubscription(subscription: Subscription): void {
+    this._eventAggregator.unsubscribe(subscription);
+  }
+
+  private _createSubscription(eventName: string, callback: EventReceivedCallback, subscribeOnce: boolean): Subscription {
+
     if (subscribeOnce) {
-      return this._eventAggregator.subscribeOnce(eventName, performSanitationCallback);
+      return this._eventAggregator.subscribeOnce(eventName, callback);
     }
 
-    return this._eventAggregator.subscribe(eventName, performSanitationCallback);
+    return this._eventAggregator.subscribe(eventName, callback);
   }
 
   private _checkIfIdentityUserIDsMatch(identityA: IIdentity, identityB: IIdentity): boolean {

--- a/src/adapters/notification_adapter.ts
+++ b/src/adapters/notification_adapter.ts
@@ -1,7 +1,5 @@
-import * as jsonwebtoken from 'jsonwebtoken';
-
 import {EventReceivedCallback, IEventAggregator, Subscription} from '@essential-projects/event_aggregator_contracts';
-import {IIdentity, TokenBody} from '@essential-projects/iam_contracts';
+import {IIdentity} from '@essential-projects/iam_contracts';
 import {Messages} from '@process-engine/consumer_api_contracts';
 
 export class NotificationAdapter {
@@ -225,11 +223,7 @@ export class NotificationAdapter {
   }
 
   private _checkIfIdentityUserIDsMatch(identityA: IIdentity, identityB: IIdentity): boolean {
-
-    const decodedRequestingIdentity: TokenBody = <TokenBody> jsonwebtoken.decode(identityA.token);
-    const decodedUserTaskIdentity: TokenBody = <TokenBody> jsonwebtoken.decode(identityB.token);
-
-    return decodedRequestingIdentity.sub === decodedUserTaskIdentity.sub;
+    return identityA.userId === identityB.userId;
   }
 
   private _sanitizeInternalMessageForPublicNotification

--- a/src/consumer_api_service.ts
+++ b/src/consumer_api_service.ts
@@ -2,7 +2,7 @@
 import * as jsonwebtoken from 'jsonwebtoken';
 
 import * as EssentialProjectErrors from '@essential-projects/errors_ts';
-import {IEventAggregator} from '@essential-projects/event_aggregator_contracts';
+import {IEventAggregator, Subscription} from '@essential-projects/event_aggregator_contracts';
 import {IIAMService, IIdentity, TokenBody} from '@essential-projects/iam_contracts';
 import {DataModels, IConsumerApi, Messages} from '@process-engine/consumer_api_contracts';
 import {
@@ -75,68 +75,89 @@ export class ConsumerApiService implements IConsumerApi {
   }
 
   // Notifications
-  public async onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<void> {
+  public async onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<Subscription> {
     await this._iamService.ensureHasClaim(identity, this._canSubscribeToEventsClaim);
-    this._notificationAdapter.onUserTaskWaiting(identity, callback);
+
+    return this._notificationAdapter.onUserTaskWaiting(identity, callback);
   }
 
-  public async onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Promise<void> {
+  public async onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Promise<Subscription> {
     await this._iamService.ensureHasClaim(identity, this._canSubscribeToEventsClaim);
-    this._notificationAdapter.onUserTaskFinished(identity, callback);
+
+    return this._notificationAdapter.onUserTaskFinished(identity, callback);
   }
 
-  public async onUserTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<void> {
+  public async onUserTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<Subscription> {
     await this._iamService.ensureHasClaim(identity, this._canSubscribeToEventsClaim);
-    this._notificationAdapter.onUserTaskForIdentityWaiting(identity, callback);
+
+    return this._notificationAdapter.onUserTaskForIdentityWaiting(identity, callback);
   }
 
-  public async onUserTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Promise<void> {
+  public async onUserTaskForIdentityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
+  ): Promise<Subscription> {
     await this._iamService.ensureHasClaim(identity, this._canSubscribeToEventsClaim);
-    this._notificationAdapter.onUserTaskForIdentityFinished(identity, callback);
+
+    return this._notificationAdapter.onUserTaskForIdentityFinished(identity, callback);
   }
 
-  public async onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Promise<void> {
+  public async onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Promise<Subscription> {
     await this._iamService.ensureHasClaim(identity, this._canSubscribeToEventsClaim);
-    this._notificationAdapter.onManualTaskWaiting(identity, callback);
+
+    return this._notificationAdapter.onManualTaskWaiting(identity, callback);
   }
 
-  public async onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Promise<void> {
+  public async onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Promise<Subscription> {
     await this._iamService.ensureHasClaim(identity, this._canSubscribeToEventsClaim);
-    this._notificationAdapter.onManualTaskFinished(identity, callback);
+
+    return this._notificationAdapter.onManualTaskFinished(identity, callback);
   }
 
-  public async onManualTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Promise<void> {
+  public async onManualTaskForIdentityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
+  ): Promise<Subscription> {
     await this._iamService.ensureHasClaim(identity, this._canSubscribeToEventsClaim);
-    this._notificationAdapter.onManualTaskForIdentityWaiting(identity, callback);
+
+    return this._notificationAdapter.onManualTaskForIdentityWaiting(identity, callback);
   }
 
-  public async onManualTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Promise<void> {
+  public async onManualTaskForIdentityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
+  ): Promise<Subscription> {
     await this._iamService.ensureHasClaim(identity, this._canSubscribeToEventsClaim);
-    this._notificationAdapter.onManualTaskForIdentityFinished(identity, callback);
+
+    return this._notificationAdapter.onManualTaskForIdentityFinished(identity, callback);
   }
 
-  public async onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): Promise<void> {
+  public async onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): Promise<Subscription> {
     await this._iamService.ensureHasClaim(identity, this._canSubscribeToEventsClaim);
-    this._notificationAdapter.onProcessStarted(identity, callback);
+
+    return this._notificationAdapter.onProcessStarted(identity, callback);
   }
 
   public async onProcessWithProcessModelIdStarted(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnProcessStartedCallback,
     processModelId: string,
-  ): Promise<void> {
+  ): Promise<Subscription> {
     await this._iamService.ensureHasClaim(identity, this._canSubscribeToEventsClaim);
-    this._notificationAdapter.onProcessWithProcessModelIdStarted(identity, callback, processModelId);
+
+    return this._notificationAdapter.onProcessWithProcessModelIdStarted(identity, callback, processModelId);
   }
 
-  public async onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): Promise<void> {
+  public async onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): Promise<Subscription> {
     await this._iamService.ensureHasClaim(identity, this._canSubscribeToEventsClaim);
-    this._notificationAdapter.onProcessEnded(identity, callback);
+
+    return this._notificationAdapter.onProcessEnded(identity, callback);
   }
 
-  public async onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): Promise<void> {
+  public async onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): Promise<Subscription> {
     await this._iamService.ensureHasClaim(identity, this._canSubscribeToEventsClaim);
-    this._notificationAdapter.onProcessTerminated(identity, callback);
+
+    return this._notificationAdapter.onProcessTerminated(identity, callback);
   }
 
   // Process models and instances

--- a/src/consumer_api_service.ts
+++ b/src/consumer_api_service.ts
@@ -75,89 +75,125 @@ export class ConsumerApiService implements IConsumerApi {
   }
 
   // Notifications
-  public async onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<Subscription> {
+  public async onUserTaskWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
     await this._iamService.ensureHasClaim(identity, this._canSubscribeToEventsClaim);
 
-    return this._notificationAdapter.onUserTaskWaiting(identity, callback);
+    return this._notificationAdapter.onUserTaskWaiting(identity, callback, subscribeOnce);
   }
 
-  public async onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Promise<Subscription> {
+  public async onUserTaskFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
     await this._iamService.ensureHasClaim(identity, this._canSubscribeToEventsClaim);
 
-    return this._notificationAdapter.onUserTaskFinished(identity, callback);
+    return this._notificationAdapter.onUserTaskFinished(identity, callback, subscribeOnce);
   }
 
-  public async onUserTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<Subscription> {
+  public async onUserTaskForIdentityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
     await this._iamService.ensureHasClaim(identity, this._canSubscribeToEventsClaim);
 
-    return this._notificationAdapter.onUserTaskForIdentityWaiting(identity, callback);
+    return this._notificationAdapter.onUserTaskForIdentityWaiting(identity, callback, subscribeOnce);
   }
 
   public async onUserTaskForIdentityFinished(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
+    subscribeOnce: boolean = false,
   ): Promise<Subscription> {
     await this._iamService.ensureHasClaim(identity, this._canSubscribeToEventsClaim);
 
-    return this._notificationAdapter.onUserTaskForIdentityFinished(identity, callback);
+    return this._notificationAdapter.onUserTaskForIdentityFinished(identity, callback, subscribeOnce);
   }
 
-  public async onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Promise<Subscription> {
+  public async onManualTaskWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
     await this._iamService.ensureHasClaim(identity, this._canSubscribeToEventsClaim);
 
-    return this._notificationAdapter.onManualTaskWaiting(identity, callback);
+    return this._notificationAdapter.onManualTaskWaiting(identity, callback, subscribeOnce);
   }
 
-  public async onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Promise<Subscription> {
+  public async onManualTaskFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
     await this._iamService.ensureHasClaim(identity, this._canSubscribeToEventsClaim);
 
-    return this._notificationAdapter.onManualTaskFinished(identity, callback);
+    return this._notificationAdapter.onManualTaskFinished(identity, callback, subscribeOnce);
   }
 
   public async onManualTaskForIdentityWaiting(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
+    subscribeOnce: boolean = false,
   ): Promise<Subscription> {
     await this._iamService.ensureHasClaim(identity, this._canSubscribeToEventsClaim);
 
-    return this._notificationAdapter.onManualTaskForIdentityWaiting(identity, callback);
+    return this._notificationAdapter.onManualTaskForIdentityWaiting(identity, callback, subscribeOnce);
   }
 
   public async onManualTaskForIdentityFinished(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
+    subscribeOnce: boolean = false,
   ): Promise<Subscription> {
     await this._iamService.ensureHasClaim(identity, this._canSubscribeToEventsClaim);
 
-    return this._notificationAdapter.onManualTaskForIdentityFinished(identity, callback);
+    return this._notificationAdapter.onManualTaskForIdentityFinished(identity, callback, subscribeOnce);
   }
 
-  public async onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): Promise<Subscription> {
+  public async onProcessStarted(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessStartedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
     await this._iamService.ensureHasClaim(identity, this._canSubscribeToEventsClaim);
 
-    return this._notificationAdapter.onProcessStarted(identity, callback);
+    return this._notificationAdapter.onProcessStarted(identity, callback, subscribeOnce);
   }
 
   public async onProcessWithProcessModelIdStarted(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnProcessStartedCallback,
     processModelId: string,
+    subscribeOnce: boolean = false,
   ): Promise<Subscription> {
     await this._iamService.ensureHasClaim(identity, this._canSubscribeToEventsClaim);
 
-    return this._notificationAdapter.onProcessWithProcessModelIdStarted(identity, callback, processModelId);
+    return this._notificationAdapter.onProcessWithProcessModelIdStarted(identity, callback, processModelId, subscribeOnce);
   }
 
-  public async onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): Promise<Subscription> {
+  public async onProcessEnded(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessEndedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
     await this._iamService.ensureHasClaim(identity, this._canSubscribeToEventsClaim);
 
-    return this._notificationAdapter.onProcessEnded(identity, callback);
+    return this._notificationAdapter.onProcessEnded(identity, callback, subscribeOnce);
   }
 
-  public async onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): Promise<Subscription> {
+  public async onProcessTerminated(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessTerminatedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
     await this._iamService.ensureHasClaim(identity, this._canSubscribeToEventsClaim);
 
-    return this._notificationAdapter.onProcessTerminated(identity, callback);
+    return this._notificationAdapter.onProcessTerminated(identity, callback, subscribeOnce);
   }
 
   public async removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void> {

--- a/src/consumer_api_service.ts
+++ b/src/consumer_api_service.ts
@@ -199,7 +199,7 @@ export class ConsumerApiService implements IConsumerApi {
   public async removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void> {
     await this._iamService.ensureHasClaim(identity, this._canSubscribeToEventsClaim);
 
-    this._notificationAdapter.removeSubscription(identity, subscription);
+    this._notificationAdapter.removeSubscription(subscription);
   }
 
   // Process models and instances

--- a/src/consumer_api_service.ts
+++ b/src/consumer_api_service.ts
@@ -1,6 +1,4 @@
 // tslint:disable:max-file-line-count
-import * as jsonwebtoken from 'jsonwebtoken';
-
 import * as EssentialProjectErrors from '@essential-projects/errors_ts';
 import {IEventAggregator, Subscription} from '@essential-projects/event_aggregator_contracts';
 import {IIAMService, IIdentity, TokenBody} from '@essential-projects/iam_contracts';
@@ -728,10 +726,6 @@ export class ConsumerApiService implements IConsumerApi {
   }
 
   private _checkIfIdentityUserIDsMatch(identityA: IIdentity, identityB: IIdentity): boolean {
-
-    const decodedRequestingIdentity: TokenBody = <TokenBody> jsonwebtoken.decode(identityA.token);
-    const decodedUserTaskIdentity: TokenBody = <TokenBody> jsonwebtoken.decode(identityB.token);
-
-    return decodedRequestingIdentity.sub === decodedUserTaskIdentity.sub;
+    return identityA.userId === identityB.userId;
   }
 }

--- a/src/consumer_api_service.ts
+++ b/src/consumer_api_service.ts
@@ -160,6 +160,12 @@ export class ConsumerApiService implements IConsumerApi {
     return this._notificationAdapter.onProcessTerminated(identity, callback);
   }
 
+  public async removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void> {
+    await this._iamService.ensureHasClaim(identity, this._canSubscribeToEventsClaim);
+
+    this._notificationAdapter.removeSubscription(identity, subscription);
+  }
+
   // Process models and instances
   public async getProcessModels(identity: IIdentity): Promise<DataModels.ProcessModels.ProcessModelList> {
 


### PR DESCRIPTION
**Changes:**

1. Implement the `removeSubscription` UseCase, which allows a user to unsubscribe from a notification.
2. Implement `subscribeOnce` flag for all notification Subscriptions. This works pretty much like the `subscribeOnce` UseCase for the EventAggregator.
3. Refactor all Notification subscription functions so that they return the created subscriptions.

**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/#135
Part of https://github.com/process-engine/process_engine_runtime/issues/#157
Part of https://github.com/process-engine/process_engine_runtime/issues/#206

PR: #83

## How can others test the changes?

- Create some subscriptions for notifications
- Trigger these notifications to receive them
- Unsubscribe from a notification
- Trigger the notification again
- Notice that the callback you provided for that notification will no longer get triggered

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).