### PR TITLE
🐛 Fix waiting user task queries

### DIFF
--- a/ioc_module.js
+++ b/ioc_module.js
@@ -25,17 +25,17 @@ function registerInContainer(container) {
 
   container
     .register('ConsumerApiEventConverter', EventConverter)
-    .dependencies('ProcessModelService', 'ProcessModelFacadeFactory')
+    .dependencies('CorrelationService', 'ProcessModelService', 'ProcessModelFacadeFactory')
     .singleton();
 
   container
     .register('ConsumerApiUserTaskConverter', UserTaskConverter)
-    .dependencies('ProcessModelService', 'FlowNodeInstanceService', 'ProcessModelFacadeFactory', 'ProcessTokenFacadeFactory')
+    .dependencies('CorrelationService', 'ProcessModelService', 'FlowNodeInstanceService', 'ProcessModelFacadeFactory', 'ProcessTokenFacadeFactory')
     .singleton();
 
   container
     .register('ConsumerApiManualTaskConverter', ManualTaskConverter)
-    .dependencies('ProcessModelService', 'ProcessModelFacadeFactory')
+    .dependencies('CorrelationService', 'ProcessModelService', 'ProcessModelFacadeFactory')
     .singleton();
 
   container

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/consumer_api_core",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "the api-package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@essential-projects/event_aggregator_contracts": "~4.0.0",
     "@essential-projects/iam_contracts": "~3.4.0",
     "@process-engine/consumer_api_contracts": "~4.1.0",
-    "@process-engine/process_engine_contracts": "~36.6.0",
+    "@process-engine/process_engine_contracts": "feature~expose_get_by_hash_on_process_model_service",
     "bluebird": "~3.5.2",
     "bluebird-global": "~1.0.1",
     "loggerhythm": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@essential-projects/event_aggregator_contracts": "~4.0.0",
     "@essential-projects/iam_contracts": "~3.4.0",
     "@process-engine/consumer_api_contracts": "~4.1.0",
-    "@process-engine/process_engine_contracts": "feature~expose_get_by_hash_on_process_model_service",
+    "@process-engine/process_engine_contracts": "~37.0.1",
     "bluebird": "~3.5.2",
     "bluebird-global": "~1.0.1",
     "loggerhythm": "^3.0.3",

--- a/src/converters/event_converter.ts
+++ b/src/converters/event_converter.ts
@@ -68,13 +68,17 @@ export class EventConverter {
 
     let processModel: Model.Types.Process;
 
-    const cacheHasMatchingEntry: boolean = ProcessModelCache.hasEntry(flowNodeInstance.processInstanceId);
+    // We must store the ProcessModel for each user, to account for lane-restrictions.
+    // Some users may not be able to see some lanes that are visible to others.
+    const cacheKeyToUse: string = `${flowNodeInstance.processInstanceId}-${identity.userId}`;
+
+    const cacheHasMatchingEntry: boolean = ProcessModelCache.hasEntry(cacheKeyToUse);
     if (cacheHasMatchingEntry) {
-      processModel = ProcessModelCache.get(flowNodeInstance.processInstanceId);
+      processModel = ProcessModelCache.get(cacheKeyToUse);
     } else {
       const processModelHash: string = await this.getProcessModelHashForProcessInstance(identity, flowNodeInstance.processInstanceId);
       processModel = await this._processModelService.getByHash(identity, flowNodeInstance.processModelId, processModelHash);
-      ProcessModelCache.add(flowNodeInstance.processInstanceId, processModel);
+      ProcessModelCache.add(cacheKeyToUse, processModel);
     }
 
     const processModelFacade: IProcessModelFacade = this._processModelFacadeFactory.create(processModel);

--- a/src/converters/event_converter.ts
+++ b/src/converters/event_converter.ts
@@ -3,6 +3,7 @@ import {IIdentity} from '@essential-projects/iam_contracts';
 import {InternalServerError} from '@essential-projects/errors_ts';
 import {DataModels} from '@process-engine/consumer_api_contracts';
 import {
+  ICorrelationService,
   IProcessModelFacade,
   IProcessModelFacadeFactory,
   IProcessModelService,
@@ -10,19 +11,20 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-/**
- * Used to cache ProcessModels during Event conversion.
- * This helps to avoid repeated queries against the database for the same ProcessModel.
- */
-type ProcessModelCache = {[processModelId: string]: Model.Types.Process};
+import * as ProcessModelCache from './process_model_cache';
 
 export class EventConverter {
 
+  private readonly _correlationService: ICorrelationService;
   private readonly _processModelService: IProcessModelService;
   private readonly _processModelFacadeFactory: IProcessModelFacadeFactory;
 
-  constructor(processModelService: IProcessModelService,
-              processModelFacadeFactory: IProcessModelFacadeFactory) {
+  constructor(
+    correlationService: ICorrelationService,
+    processModelService: IProcessModelService,
+    processModelFacadeFactory: IProcessModelFacadeFactory,
+  ) {
+    this._correlationService = correlationService;
     this._processModelService = processModelService;
     this._processModelFacadeFactory = processModelFacadeFactory;
   }
@@ -30,8 +32,6 @@ export class EventConverter {
   public async convertEvents(identity: IIdentity, suspendedFlowNodes: Array<Runtime.Types.FlowNodeInstance>): Promise<DataModels.Events.EventList> {
 
     const suspendedEvents: Array<DataModels.Events.Event> = [];
-
-    const processModelCache: ProcessModelCache = {};
 
     for (const suspendedFlowNode of suspendedFlowNodes) {
 
@@ -45,7 +45,7 @@ export class EventConverter {
       }
 
       const processModelFacade: IProcessModelFacade =
-        await this.getProcessModelForFlowNodeInstance(identity, suspendedFlowNode.processModelId, processModelCache);
+        await this.getProcessModelForFlowNodeInstance(identity, suspendedFlowNode);
 
       const flowNodeModel: Model.Base.FlowNode = processModelFacade.getFlowNodeById(suspendedFlowNode.flowNodeId);
 
@@ -63,30 +63,31 @@ export class EventConverter {
 
   private async getProcessModelForFlowNodeInstance(
     identity: IIdentity,
-    processModelId: string,
-    processModelCache: ProcessModelCache,
+    flowNodeInstance: Runtime.Types.FlowNodeInstance,
   ): Promise<IProcessModelFacade> {
 
     let processModel: Model.Types.Process;
 
-    // To avoid repeated Queries against the database for the same ProcessModel,
-    // the retrieved ProcessModels will be cached.
-    // So when we want to get a ProcessModel for an Event, we first check the cache and
-    // get the ProcessModel from there.
-    // We only query the database, if the ProcessModel was not yet retrieved.
-    // This avoids timeouts and request-lags when converting large numbers of events.
-    const cacheHasMatchingEntry: boolean = processModelCache[processModelId] !== undefined;
-
+    const cacheHasMatchingEntry: boolean = ProcessModelCache.hasEntry(flowNodeInstance.processInstanceId);
     if (cacheHasMatchingEntry) {
-      processModel = processModelCache[processModelId];
+      processModel = ProcessModelCache.get(flowNodeInstance.processInstanceId);
     } else {
-      processModel = await this._processModelService.getProcessModelById(identity, processModelId);
-      processModelCache[processModelId] = processModel;
+      const processModelHash: string = await this.getProcessModelHashForProcessInstance(identity, flowNodeInstance.processInstanceId);
+      processModel = await this._processModelService.getByHash(identity, flowNodeInstance.processModelId, processModelHash);
+      ProcessModelCache.add(flowNodeInstance.processInstanceId, processModel);
     }
 
     const processModelFacade: IProcessModelFacade = this._processModelFacadeFactory.create(processModel);
 
     return processModelFacade;
+  }
+
+  private async getProcessModelHashForProcessInstance(identity: IIdentity, processInstanceId: string): Promise<string> {
+    const correlationForProcessInstance: Runtime.Types.Correlation =
+      await this._correlationService.getByProcessInstanceId(identity, processInstanceId);
+
+    // Note that ProcessInstances will only ever have one processModel and therefore only one hash attached to them.
+    return correlationForProcessInstance.processModels[0].hash;
   }
 
   private _convertToConsumerApiEvent(flowNodeModel: Model.Events.Event, suspendedFlowNode: Runtime.Types.FlowNodeInstance): DataModels.Events.Event {

--- a/src/converters/manual_task_converter.ts
+++ b/src/converters/manual_task_converter.ts
@@ -2,25 +2,28 @@ import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {DataModels} from '@process-engine/consumer_api_contracts';
 import {
+  ICorrelationService,
   IProcessModelFacade,
   IProcessModelFacadeFactory,
   IProcessModelService,
   Model,
   Runtime,
 } from '@process-engine/process_engine_contracts';
-/**
- * Used to cache process models during ManualTask conversion.
- * This helps to avoid repeated queries against the database for the same ProcessModel.
- */
-type ProcessModelCache = {[processModelId: string]: Model.Types.Process};
+
+import * as ProcessModelCache from './process_model_cache';
 
 export class ManualTaskConverter {
 
+  private readonly _correlationService: ICorrelationService;
   private readonly _processModelService: IProcessModelService;
   private readonly _processModelFacadeFactory: IProcessModelFacadeFactory;
 
-  constructor(processModelService: IProcessModelService,
-              processModelFacadeFactory: IProcessModelFacadeFactory) {
+  constructor(
+    correlationService: ICorrelationService,
+    processModelService: IProcessModelService,
+    processModelFacadeFactory: IProcessModelFacadeFactory,
+  ) {
+    this._correlationService = correlationService;
     this._processModelService = processModelService;
     this._processModelFacadeFactory = processModelFacadeFactory;
   }
@@ -32,33 +35,13 @@ export class ManualTaskConverter {
 
     const suspendedManualTasks: Array<DataModels.ManualTasks.ManualTask> = [];
 
-    const processModelCache: ProcessModelCache = {};
-
     for (const suspendedFlowNode of suspendedFlowNodes) {
 
-      const currentProcessToken: Runtime.Types.ProcessToken = suspendedFlowNode.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-        return token.type === Runtime.Types.ProcessTokenType.onSuspend;
-      });
-
-      let processModel: Model.Types.Process;
-
-      // To avoid repeated Queries against the database for the same process model,
-      // the retrieved process models will be cached.
-      // So when we want to get a ProcessModel for a ManualTask, we first check the cache and
-      // get the ProcessModel from there.
-      // We only query the database, if the ProcessModel was not yet retrieved.
-      // This avoids timeouts and request-lags when converting large numbers of manual tasks.
-      const modelInCache: boolean = processModelCache[currentProcessToken.processModelId] !== undefined;
-
-      if (modelInCache) {
-        processModel = processModelCache[currentProcessToken.processModelId];
-      } else {
-        processModel = await this._processModelService.getProcessModelById(identity, currentProcessToken.processModelId);
-        processModelCache[currentProcessToken.processModelId] = processModel;
-      }
+      const processModelFacade: IProcessModelFacade =
+        await this.getProcessModelForFlowNodeInstance(identity, suspendedFlowNode);
 
       const manualTask: DataModels.ManualTasks.ManualTask =
-        await this._convertSuspendedFlowNodeToManualTask(suspendedFlowNode, currentProcessToken, processModel);
+        await this._convertSuspendedFlowNodeToManualTask(suspendedFlowNode, processModelFacade);
 
       const taskIsNotAManualTask: boolean = manualTask === undefined;
       if (taskIsNotAManualTask) {
@@ -75,13 +58,40 @@ export class ManualTaskConverter {
     return manualTaskList;
   }
 
-  private async _convertSuspendedFlowNodeToManualTask(
+  private async getProcessModelForFlowNodeInstance(
+    identity: IIdentity,
     flowNodeInstance: Runtime.Types.FlowNodeInstance,
-    currentProcessToken: Runtime.Types.ProcessToken,
-    processModel: Model.Types.Process,
-  ): Promise<DataModels.ManualTasks.ManualTask> {
+  ): Promise<IProcessModelFacade> {
+
+    let processModel: Model.Types.Process;
+
+    const cacheHasMatchingEntry: boolean = ProcessModelCache.hasEntry(flowNodeInstance.processInstanceId);
+    if (cacheHasMatchingEntry) {
+      processModel = ProcessModelCache.get(flowNodeInstance.processInstanceId);
+    } else {
+      const processModelHash: string = await this.getProcessModelHashForProcessInstance(identity, flowNodeInstance.processInstanceId);
+      processModel = await this._processModelService.getByHash(identity, flowNodeInstance.processModelId, processModelHash);
+      ProcessModelCache.add(flowNodeInstance.processInstanceId, processModel);
+    }
 
     const processModelFacade: IProcessModelFacade = this._processModelFacadeFactory.create(processModel);
+
+    return processModelFacade;
+  }
+
+  private async getProcessModelHashForProcessInstance(identity: IIdentity, processInstanceId: string): Promise<string> {
+    const correlationForProcessInstance: Runtime.Types.Correlation =
+      await this._correlationService.getByProcessInstanceId(identity, processInstanceId);
+
+    // Note that ProcessInstances will only ever have one processModel and therefore only one hash attached to them.
+    return correlationForProcessInstance.processModels[0].hash;
+  }
+
+  private async _convertSuspendedFlowNodeToManualTask(
+    flowNodeInstance: Runtime.Types.FlowNodeInstance,
+    processModelFacade: IProcessModelFacade,
+  ): Promise<DataModels.ManualTasks.ManualTask> {
+
     const flowNodeModel: Model.Base.FlowNode = processModelFacade.getFlowNodeById(flowNodeInstance.flowNodeId);
 
     // Note that ManualTasks are not the only types of FlowNodes that can be suspended.
@@ -92,13 +102,18 @@ export class ManualTaskConverter {
       return undefined;
     }
 
-    return this._convertToConsumerApiManualTask(flowNodeModel as Model.Activities.ManualTask, flowNodeInstance, currentProcessToken);
+    return this._convertToConsumerApiManualTask(flowNodeModel as Model.Activities.ManualTask, flowNodeInstance);
   }
 
-  private async _convertToConsumerApiManualTask(manualTask: Model.Activities.ManualTask,
-                                                flowNodeInstance: Runtime.Types.FlowNodeInstance,
-                                                currentProcessToken: Runtime.Types.ProcessToken,
-                                              ): Promise<DataModels.ManualTasks.ManualTask> {
+  private async _convertToConsumerApiManualTask(
+    manualTask: Model.Activities.ManualTask,
+    flowNodeInstance: Runtime.Types.FlowNodeInstance,
+  ): Promise<DataModels.ManualTasks.ManualTask> {
+
+    const currentProcessToken: Runtime.Types.ProcessToken =
+      flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
+        return token.type === Runtime.Types.ProcessTokenType.onSuspend;
+      });
 
     const consumerApiManualTask: DataModels.ManualTasks.ManualTask = {
       id: flowNodeInstance.flowNodeId,

--- a/src/converters/manual_task_converter.ts
+++ b/src/converters/manual_task_converter.ts
@@ -65,13 +65,17 @@ export class ManualTaskConverter {
 
     let processModel: Model.Types.Process;
 
-    const cacheHasMatchingEntry: boolean = ProcessModelCache.hasEntry(flowNodeInstance.processInstanceId);
+    // We must store the ProcessModel for each user, to account for lane-restrictions.
+    // Some users may not be able to see some lanes that are visible to others.
+    const cacheKeyToUse: string = `${flowNodeInstance.processInstanceId}-${identity.userId}`;
+
+    const cacheHasMatchingEntry: boolean = ProcessModelCache.hasEntry(cacheKeyToUse);
     if (cacheHasMatchingEntry) {
-      processModel = ProcessModelCache.get(flowNodeInstance.processInstanceId);
+      processModel = ProcessModelCache.get(cacheKeyToUse);
     } else {
       const processModelHash: string = await this.getProcessModelHashForProcessInstance(identity, flowNodeInstance.processInstanceId);
       processModel = await this._processModelService.getByHash(identity, flowNodeInstance.processModelId, processModelHash);
-      ProcessModelCache.add(flowNodeInstance.processInstanceId, processModel);
+      ProcessModelCache.add(cacheKeyToUse, processModel);
     }
 
     const processModelFacade: IProcessModelFacade = this._processModelFacadeFactory.create(processModel);

--- a/src/converters/process_model_cache.ts
+++ b/src/converters/process_model_cache.ts
@@ -1,0 +1,21 @@
+import {Model} from '@process-engine/process_engine_contracts';
+
+/**
+ * Used to cache ProcessModels during UserTask conversion.
+ * This helps to avoid repeated queries against the database for the same ProcessModel.
+ */
+type ProcessModelCache = {[processInstanceId: string]: Model.Types.Process};
+
+const processModelCache: ProcessModelCache = {};
+
+export function hasEntry(processInstanceId: string): boolean {
+  return processModelCache[processInstanceId] !== undefined;
+}
+
+export function add(processInstanceId: string, processModel: Model.Types.Process): void {
+  processModelCache[processInstanceId] = processModel;
+}
+
+export function get(processInstanceId: string): Model.Types.Process {
+  return processModelCache[processInstanceId];
+}

--- a/src/converters/process_model_cache.ts
+++ b/src/converters/process_model_cache.ts
@@ -4,18 +4,18 @@ import {Model} from '@process-engine/process_engine_contracts';
  * Used to cache ProcessModels during conversion of suspended FlowNodeInstances.
  * This helps to avoid repeated queries against the database for the same ProcessModel.
  */
-type ProcessModelCache = {[processInstanceId: string]: Model.Types.Process};
+type ProcessModelCache = {[cacheEntryKey: string]: Model.Types.Process};
 
 const processModelCache: ProcessModelCache = {};
 
-export function hasEntry(processInstanceId: string): boolean {
-  return processModelCache[processInstanceId] !== undefined;
+export function hasEntry(cacheEntryKey: string): boolean {
+  return processModelCache[cacheEntryKey] !== undefined;
 }
 
-export function add(processInstanceId: string, processModel: Model.Types.Process): void {
-  processModelCache[processInstanceId] = processModel;
+export function add(cacheEntryKey: string, processModel: Model.Types.Process): void {
+  processModelCache[cacheEntryKey] = processModel;
 }
 
-export function get(processInstanceId: string): Model.Types.Process {
-  return processModelCache[processInstanceId];
+export function get(cacheEntryKey: string): Model.Types.Process {
+  return processModelCache[cacheEntryKey];
 }

--- a/src/converters/process_model_cache.ts
+++ b/src/converters/process_model_cache.ts
@@ -1,7 +1,7 @@
 import {Model} from '@process-engine/process_engine_contracts';
 
 /**
- * Used to cache ProcessModels during UserTask conversion.
+ * Used to cache ProcessModels during conversion of suspended FlowNodeInstances.
  * This helps to avoid repeated queries against the database for the same ProcessModel.
  */
 type ProcessModelCache = {[processInstanceId: string]: Model.Types.Process};

--- a/src/converters/user_task_converter.ts
+++ b/src/converters/user_task_converter.ts
@@ -80,13 +80,17 @@ export class UserTaskConverter {
 
     let processModel: Model.Types.Process;
 
-    const cacheHasMatchingEntry: boolean = ProcessModelCache.hasEntry(flowNodeInstance.processInstanceId);
+    // We must store the ProcessModel for each user, to account for lane-restrictions.
+    // Some users may not be able to see some lanes that are visible to others.
+    const cacheKeyToUse: string = `${flowNodeInstance.processInstanceId}-${identity.userId}`;
+
+    const cacheHasMatchingEntry: boolean = ProcessModelCache.hasEntry(cacheKeyToUse);
     if (cacheHasMatchingEntry) {
-      processModel = ProcessModelCache.get(flowNodeInstance.processInstanceId);
+      processModel = ProcessModelCache.get(cacheKeyToUse);
     } else {
       const processModelHash: string = await this.getProcessModelHashForProcessInstance(identity, flowNodeInstance.processInstanceId);
       processModel = await this._processModelService.getByHash(identity, flowNodeInstance.processModelId, processModelHash);
-      ProcessModelCache.add(flowNodeInstance.processInstanceId, processModel);
+      ProcessModelCache.add(cacheKeyToUse, processModel);
     }
 
     const processModelFacade: IProcessModelFacade = this._processModelFacadeFactory.create(processModel);

--- a/src/converters/user_task_converter.ts
+++ b/src/converters/user_task_converter.ts
@@ -2,6 +2,7 @@ import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {DataModels} from '@process-engine/consumer_api_contracts';
 import {
+  ICorrelationService,
   IFlowNodeInstanceService,
   IProcessModelFacade,
   IProcessModelFacadeFactory,
@@ -13,23 +14,24 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-/**
- * Used to cache ProcessModels during UserTask conversion.
- * This helps to avoid repeated queries against the database for the same ProcessModel.
- */
-type ProcessModelCache = {[processModelId: string]: Model.Types.Process};
+import * as ProcessModelCache from './process_model_cache';
 
 export class UserTaskConverter {
 
+  private readonly _correlationService: ICorrelationService;
   private readonly _processModelService: IProcessModelService;
   private readonly _flowNodeInstanceService: IFlowNodeInstanceService;
   private readonly _processModelFacadeFactory: IProcessModelFacadeFactory;
   private readonly _processTokenFacadeFactory: IProcessTokenFacadeFactory;
 
-  constructor(processModelService: IProcessModelService,
-              flowNodeInstanceService: IFlowNodeInstanceService,
-              processModelFacadeFactory: IProcessModelFacadeFactory,
-              processTokenFacadeFactory: IProcessTokenFacadeFactory) {
+  constructor(
+    correlationRepository: ICorrelationService,
+    processModelService: IProcessModelService,
+    flowNodeInstanceService: IFlowNodeInstanceService,
+    processModelFacadeFactory: IProcessModelFacadeFactory,
+    processTokenFacadeFactory: IProcessTokenFacadeFactory,
+  ) {
+    this._correlationService = correlationRepository;
     this._processModelService = processModelService;
     this._flowNodeInstanceService = flowNodeInstanceService;
     this._processModelFacadeFactory = processModelFacadeFactory;
@@ -43,12 +45,10 @@ export class UserTaskConverter {
 
     const suspendedUserTasks: Array<DataModels.UserTasks.UserTask> = [];
 
-    const processModelCache: ProcessModelCache = {};
-
     for (const suspendedFlowNode of suspendedFlowNodes) {
 
       const processModelFacade: IProcessModelFacade =
-        await this.getProcessModelForFlowNodeInstance(identity, suspendedFlowNode.processModelId, processModelCache);
+        await this.getProcessModelForFlowNodeInstance(identity, suspendedFlowNode);
 
       const flowNodeModel: Model.Base.FlowNode = processModelFacade.getFlowNodeById(suspendedFlowNode.flowNodeId);
 
@@ -75,30 +75,31 @@ export class UserTaskConverter {
 
   private async getProcessModelForFlowNodeInstance(
     identity: IIdentity,
-    processModelId: string,
-    processModelCache: ProcessModelCache,
+    flowNodeInstance: Runtime.Types.FlowNodeInstance,
   ): Promise<IProcessModelFacade> {
 
     let processModel: Model.Types.Process;
 
-    // To avoid repeated Queries against the database for the same ProcessModel,
-    // the retrieved ProcessModels will be cached.
-    // So when we want to get a ProcessModel for a UserTask, we first check the cache and
-    // get the ProcessModel from there.
-    // We only query the database, if the ProcessModel was not yet retrieved.
-    // This avoids timeouts and request-lags when converting large numbers of user tasks.
-    const cacheHasMatchingEntry: boolean = processModelCache[processModelId] !== undefined;
-
+    const cacheHasMatchingEntry: boolean = ProcessModelCache.hasEntry(flowNodeInstance.processInstanceId);
     if (cacheHasMatchingEntry) {
-      processModel = processModelCache[processModelId];
+      processModel = ProcessModelCache.get(flowNodeInstance.processInstanceId);
     } else {
-      processModel = await this._processModelService.getProcessModelById(identity, processModelId);
-      processModelCache[processModelId] = processModel;
+      const processModelHash: string = await this.getProcessModelHashForProcessInstance(identity, flowNodeInstance.processInstanceId);
+      processModel = await this._processModelService.getByHash(identity, flowNodeInstance.processModelId, processModelHash);
+      ProcessModelCache.add(flowNodeInstance.processInstanceId, processModel);
     }
 
     const processModelFacade: IProcessModelFacade = this._processModelFacadeFactory.create(processModel);
 
     return processModelFacade;
+  }
+
+  private async getProcessModelHashForProcessInstance(identity: IIdentity, processInstanceId: string): Promise<string> {
+    const correlationForProcessInstance: Runtime.Types.Correlation =
+      await this._correlationService.getByProcessInstanceId(identity, processInstanceId);
+
+    // Note that ProcessInstances will only ever have one processModel and therefore only one hash attached to them.
+    return correlationForProcessInstance.processModels[0].hash;
   }
 
   private async convertToConsumerApiUserTask(


### PR DESCRIPTION
**Changes:**

1. Query the correct process model version, when converting suspended FlowNodeInstances.
2. Use a common ProcessModel cache for all converters.
3. Fix a severe security leak, which allowed users to bypass claim checks when retrieving cached process models. 

PR: #84

## How can others test the changes?

- Start a UserTask/ManualTask
- Update the ProcessModel, by renaming or removing the task in question
- Query all waiting UserTasks/ManualTasks
- See the task is still listed

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).