### PR TITLE
♻️ Refactor expected parameters for process execution

### DIFF
--- a/ioc_module.js
+++ b/ioc_module.js
@@ -15,7 +15,7 @@ function registerInContainer(container) {
 
   container
     .register('ProcessModelExecutionAdapter', ProcessModelExecutionAdapter)
-    .dependencies('ExecuteProcessService', 'ProcessModelUseCases')
+    .dependencies('ExecuteProcessService')
     .singleton();
 
   container

--- a/ioc_module.js
+++ b/ioc_module.js
@@ -15,7 +15,7 @@ function registerInContainer(container) {
 
   container
     .register('ProcessModelExecutionAdapter', ProcessModelExecutionAdapter)
-    .dependencies('ExecuteProcessService', 'IdentityService', 'ProcessModelUseCases')
+    .dependencies('ExecuteProcessService', 'ProcessModelUseCases')
     .singleton();
 
   container

--- a/ioc_module.js
+++ b/ioc_module.js
@@ -15,7 +15,7 @@ function registerInContainer(container) {
 
   container
     .register('ProcessModelExecutionAdapter', ProcessModelExecutionAdapter)
-    .dependencies('ExecuteProcessService')
+    .dependencies('ExecuteProcessService', 'ProcessModelUseCases')
     .singleton();
 
   container

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/consumer_api_core",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "the api-package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@process-engine/consumer_api_contracts": "^4.1.0",
     "@process-engine/correlation.contracts": "^1.0.0",
     "@process-engine/flow_node_instance.contracts": "^1.0.0",
-    "@process-engine/process_engine_contracts": "^40.0.0",
+    "@process-engine/process_engine_contracts": "feature~refactor_execute_process_parameters",
     "@process-engine/process_model.contracts": "^1.0.0",
     "bluebird": "~3.5.2",
     "bluebird-global": "~1.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@process-engine/consumer_api_contracts": "^4.1.0",
     "@process-engine/correlation.contracts": "^1.0.0",
     "@process-engine/flow_node_instance.contracts": "^1.0.0",
-    "@process-engine/process_engine_contracts": "feature~refactor_execute_process_parameters",
+    "@process-engine/process_engine_contracts": "^40.1.0",
     "@process-engine/process_model.contracts": "^1.0.0",
     "bluebird": "~3.5.2",
     "bluebird-global": "~1.0.1",

--- a/src/adapters/process_model_execution_adapter.ts
+++ b/src/adapters/process_model_execution_adapter.ts
@@ -6,7 +6,6 @@ import {
   IExecuteProcessService,
   ProcessStartedMessage,
 } from '@process-engine/process_engine_contracts';
-import {Model} from '@process-engine/process_model.contracts';
 
 import * as uuid from 'node-uuid';
 
@@ -50,7 +49,7 @@ export class ProcessModelExecutionAdapter implements IProcessModelExecutionAdapt
   private async _startProcessInstance(
     identity: IIdentity,
     correlationId: string,
-    processModel: Model.Types.Process,
+    processModelId: string,
     startEventId: string,
     payload: DataModels.ProcessModels.ProcessStartRequestPayload,
     startCallbackType: DataModels.ProcessModels.StartCallbackType,
@@ -66,7 +65,7 @@ export class ProcessModelExecutionAdapter implements IProcessModelExecutionAdapt
     const resolveImmediatelyAfterStart: boolean = startCallbackType === DataModels.ProcessModels.StartCallbackType.CallbackOnProcessInstanceCreated;
     if (resolveImmediatelyAfterStart) {
       const startResult: ProcessStartedMessage =
-        await this._executeProcessService.start(identity, processModel, startEventId, correlationId, payload.inputValues, payload.callerId);
+        await this._executeProcessService.start(identity, processModelId, startEventId, correlationId, payload.inputValues, payload.callerId);
 
       response.processInstanceId = startResult.processInstanceId;
 
@@ -81,7 +80,7 @@ export class ProcessModelExecutionAdapter implements IProcessModelExecutionAdapt
 
       processEndedMessage = await this
         ._executeProcessService
-        .startAndAwaitSpecificEndEvent(identity, processModel, startEventId, correlationId, endEventId, payload.inputValues, payload.callerId);
+        .startAndAwaitSpecificEndEvent(identity, processModelId, startEventId, correlationId, endEventId, payload.inputValues, payload.callerId);
 
       response.endEventId = processEndedMessage.flowNodeId;
       response.tokenPayload = processEndedMessage.currentToken;
@@ -93,7 +92,7 @@ export class ProcessModelExecutionAdapter implements IProcessModelExecutionAdapt
     // Start the process instance and wait for the first end event result
     processEndedMessage = await this
       ._executeProcessService
-      .startAndAwaitEndEvent(identity, processModel, startEventId, correlationId, payload.inputValues, payload.callerId);
+      .startAndAwaitEndEvent(identity, processModelId, startEventId, correlationId, payload.inputValues, payload.callerId);
 
     response.endEventId = processEndedMessage.flowNodeId;
     response.tokenPayload = processEndedMessage.currentToken;

--- a/src/adapters/process_model_execution_adapter.ts
+++ b/src/adapters/process_model_execution_adapter.ts
@@ -1,3 +1,4 @@
+import * as EssentialProjectErrors from '@essential-projects/errors_ts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {DataModels} from '@process-engine/consumer_api_contracts';
@@ -6,6 +7,7 @@ import {
   IExecuteProcessService,
   ProcessStartedMessage,
 } from '@process-engine/process_engine_contracts';
+import {IProcessModelUseCases, Model} from '@process-engine/process_model.contracts';
 
 import * as uuid from 'node-uuid';
 
@@ -23,9 +25,11 @@ export interface IProcessModelExecutionAdapter {
 export class ProcessModelExecutionAdapter implements IProcessModelExecutionAdapter {
 
   private readonly _executeProcessService: IExecuteProcessService;
+  private readonly _processModelUseCase: IProcessModelUseCases;
 
-  constructor(executeProcessService: IExecuteProcessService) {
+  constructor(executeProcessService: IExecuteProcessService, processModelUseCase: IProcessModelUseCases) {
     this._executeProcessService = executeProcessService;
+    this._processModelUseCase = processModelUseCase;
   }
 
   public async startProcessInstance(
@@ -36,6 +40,16 @@ export class ProcessModelExecutionAdapter implements IProcessModelExecutionAdapt
     startCallbackType: DataModels.ProcessModels.StartCallbackType,
     endEventId?: string,
   ): Promise<DataModels.ProcessModels.ProcessStartResponsePayload> {
+
+    const useDefaultStartCallbackType: boolean = !startCallbackType;
+    if (useDefaultStartCallbackType) {
+      startCallbackType = DataModels.ProcessModels.StartCallbackType.CallbackOnProcessInstanceCreated;
+    }
+
+    // Uses the standard IAM facade with the processModelService => The process model gets filtered.
+    const processModel: Model.Types.Process = await this._processModelUseCase.getProcessModelById(identity, processModelId);
+
+    this._validateStartRequest(processModel, startEventId, endEventId, startCallbackType);
 
     const correlationId: string = payload.correlationId || uuid.v4();
 
@@ -99,5 +113,44 @@ export class ProcessModelExecutionAdapter implements IProcessModelExecutionAdapt
     response.processInstanceId = processEndedMessage.processInstanceId;
 
     return response;
+  }
+
+  private _validateStartRequest(
+    processModel: Model.Types.Process,
+    startEventId: string,
+    endEventId: string,
+    startCallbackType: DataModels.ProcessModels.StartCallbackType,
+  ): void {
+
+    if (!Object.values(DataModels.ProcessModels.StartCallbackType).includes(startCallbackType)) {
+      throw new EssentialProjectErrors.BadRequestError(`${startCallbackType} is not a valid return option!`);
+    }
+
+    if (!processModel.isExecutable) {
+      throw new EssentialProjectErrors.BadRequestError('The process model is not executable!');
+    }
+
+    const hasMatchingStartEvent: boolean = processModel.flowNodes.some((flowNode: Model.Base.FlowNode): boolean => {
+      return flowNode.id === startEventId;
+    });
+
+    if (!hasMatchingStartEvent) {
+      throw new EssentialProjectErrors.NotFoundError(`StartEvent with ID '${startEventId}' not found!`);
+    }
+
+    if (startCallbackType === DataModels.ProcessModels.StartCallbackType.CallbackOnEndEventReached) {
+
+      if (!endEventId) {
+        throw new EssentialProjectErrors.BadRequestError(`Must provide an EndEventId, when using callback type 'CallbackOnEndEventReached'!`);
+      }
+
+      const hasMatchingEndEvent: boolean = processModel.flowNodes.some((flowNode: Model.Base.FlowNode): boolean => {
+        return flowNode.id === endEventId;
+      });
+
+      if (!hasMatchingEndEvent) {
+        throw new EssentialProjectErrors.NotFoundError(`EndEvent with ID '${startEventId}' not found!`);
+      }
+    }
   }
 }

--- a/src/adapters/process_model_execution_adapter.ts
+++ b/src/adapters/process_model_execution_adapter.ts
@@ -7,7 +7,6 @@ import {
   IExecuteProcessService,
   ProcessStartedMessage,
 } from '@process-engine/process_engine_contracts';
-import {IProcessModelUseCases, Model} from '@process-engine/process_model.contracts';
 
 import * as uuid from 'node-uuid';
 
@@ -25,11 +24,9 @@ export interface IProcessModelExecutionAdapter {
 export class ProcessModelExecutionAdapter implements IProcessModelExecutionAdapter {
 
   private readonly _executeProcessService: IExecuteProcessService;
-  private readonly _processModelUseCase: IProcessModelUseCases;
 
-  constructor(executeProcessService: IExecuteProcessService, processModelUseCase: IProcessModelUseCases) {
+  constructor(executeProcessService: IExecuteProcessService) {
     this._executeProcessService = executeProcessService;
-    this._processModelUseCase = processModelUseCase;
   }
 
   public async startProcessInstance(


### PR DESCRIPTION
**Changes:**

1. Remove the internal identity and the `IdentityService` from the `ProcessExecutionAdapter`.
    - It no longer has to query full ProcessModels, so it doesn't need that identity any more.
    - The service now only passes each ProcessModel's ID to the `ExecuteProcessService`.
2. Move logic for validating start requests to the ProcessEngineCore, since that is the service responsible for performing the executions. Letting an outside component to that is not safe.

**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/253

PR: #86

## How can others test the changes?

This is an internal refactoring, so to the outside observer, all should run exactly as before.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).