### PR TITLE
♻️ Make the StartEventId Parameter Optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@process-engine/consumer_api_contracts": "feature~optional_start_event_id",
     "@process-engine/correlation.contracts": "^1.0.0",
     "@process-engine/flow_node_instance.contracts": "^1.0.0",
-    "@process-engine/process_engine_contracts": "^40.2.0",
+    "@process-engine/process_engine_contracts": "feature~optional_start_event_id",
     "@process-engine/process_model.contracts": "^2.0.0",
     "bluebird": "~3.5.2",
     "bluebird-global": "~1.0.1",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
   "homepage": "https://github.com/process-engine/consumer_api#readme",
   "dependencies": {
     "@essential-projects/errors_ts": "^1.4.0",
-    "@process-engine/consumer_api_contracts": "feature~optional_start_event_id",
+    "@process-engine/consumer_api_contracts": "^5.0.0",
     "@process-engine/correlation.contracts": "^1.0.0",
     "@process-engine/flow_node_instance.contracts": "^1.0.0",
-    "@process-engine/process_engine_contracts": "feature~optional_start_event_id",
+    "@process-engine/process_engine_contracts": "^41.0.0",
     "@process-engine/process_model.contracts": "^2.0.0",
     "bluebird": "~3.5.2",
     "bluebird-global": "~1.0.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/process-engine/consumer_api#readme",
   "dependencies": {
     "@essential-projects/errors_ts": "^1.4.0",
-    "@process-engine/consumer_api_contracts": "^4.1.0",
+    "@process-engine/consumer_api_contracts": "feature~optional_start_event_id",
     "@process-engine/correlation.contracts": "^1.0.0",
     "@process-engine/flow_node_instance.contracts": "^1.0.0",
     "@process-engine/process_engine_contracts": "^40.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/consumer_api_core",
-  "version": "4.2.0",
+  "version": "5.0.0",
   "description": "the api-package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/src/adapters/process_model_execution_adapter.ts
+++ b/src/adapters/process_model_execution_adapter.ts
@@ -11,14 +11,12 @@ import {
 import * as uuid from 'node-uuid';
 
 export interface IProcessModelExecutionAdapter {
-  startProcessInstance(
-    identity: IIdentity,
-    processModelId: string,
-    startEventId: string,
-    payload: DataModels.ProcessModels.ProcessStartRequestPayload,
-    startCallbackType: DataModels.ProcessModels.StartCallbackType,
-    endEventId?: string,
-  ): Promise<DataModels.ProcessModels.ProcessStartResponsePayload>;
+  startProcessInstance(identity: IIdentity,
+                       processModelId: string,
+                       payload: DataModels.ProcessModels.ProcessStartRequestPayload,
+                       startCallbackType: DataModels.ProcessModels.StartCallbackType,
+                       startEventId?: string,
+                       endEventId?: string): Promise<DataModels.ProcessModels.ProcessStartResponsePayload>;
 }
 
 export class ProcessModelExecutionAdapter implements IProcessModelExecutionAdapter {
@@ -32,9 +30,9 @@ export class ProcessModelExecutionAdapter implements IProcessModelExecutionAdapt
   public async startProcessInstance(
     identity: IIdentity,
     processModelId: string,
-    startEventId: string,
     payload: DataModels.ProcessModels.ProcessStartRequestPayload,
     startCallbackType: DataModels.ProcessModels.StartCallbackType,
+    startEventId?: string,
     endEventId?: string,
   ): Promise<DataModels.ProcessModels.ProcessStartResponsePayload> {
 

--- a/src/adapters/process_model_execution_adapter.ts
+++ b/src/adapters/process_model_execution_adapter.ts
@@ -73,7 +73,7 @@ export class ProcessModelExecutionAdapter implements IProcessModelExecutionAdapt
     const resolveImmediatelyAfterStart: boolean = startCallbackType === DataModels.ProcessModels.StartCallbackType.CallbackOnProcessInstanceCreated;
     if (resolveImmediatelyAfterStart) {
       const startResult: ProcessStartedMessage =
-        await this._executeProcessService.start(identity, processModelId, startEventId, correlationId, payload.inputValues, payload.callerId);
+        await this._executeProcessService.start(identity, processModelId, correlationId, startEventId, payload.inputValues, payload.callerId);
 
       response.processInstanceId = startResult.processInstanceId;
 
@@ -88,7 +88,7 @@ export class ProcessModelExecutionAdapter implements IProcessModelExecutionAdapt
 
       processEndedMessage = await this
         ._executeProcessService
-        .startAndAwaitSpecificEndEvent(identity, processModelId, startEventId, correlationId, endEventId, payload.inputValues, payload.callerId);
+        .startAndAwaitSpecificEndEvent(identity, processModelId, correlationId, endEventId, payload.inputValues, startEventId, payload.callerId);
 
       response.endEventId = processEndedMessage.flowNodeId;
       response.tokenPayload = processEndedMessage.currentToken;
@@ -100,7 +100,7 @@ export class ProcessModelExecutionAdapter implements IProcessModelExecutionAdapt
     // Start the process instance and wait for the first end event result
     processEndedMessage = await this
       ._executeProcessService
-      .startAndAwaitEndEvent(identity, processModelId, startEventId, correlationId, payload.inputValues, payload.callerId);
+      .startAndAwaitEndEvent(identity, processModelId, correlationId, startEventId, payload.inputValues, payload.callerId);
 
     response.endEventId = processEndedMessage.flowNodeId;
     response.tokenPayload = processEndedMessage.currentToken;

--- a/src/adapters/process_model_execution_adapter.ts
+++ b/src/adapters/process_model_execution_adapter.ts
@@ -72,8 +72,17 @@ export class ProcessModelExecutionAdapter implements IProcessModelExecutionAdapt
     // Only start the process instance and return
     const resolveImmediatelyAfterStart: boolean = startCallbackType === DataModels.ProcessModels.StartCallbackType.CallbackOnProcessInstanceCreated;
     if (resolveImmediatelyAfterStart) {
+<<<<<<< HEAD
       const startResult: ProcessStartedMessage =
         await this._executeProcessService.start(identity, processModelId, startEventId, correlationId, payload.inputValues, payload.callerId);
+=======
+      const startResult: ProcessStartedMessage = await this.executeProcessService.start(identity,
+                                                                                        processModel,
+                                                                                        correlationId,
+                                                                                        startEventId,
+                                                                                        payload.inputValues,
+                                                                                        payload.callerId);
+>>>>>>> :bug: Fix Wrong Parameters
 
       response.processInstanceId = startResult.processInstanceId;
 

--- a/src/adapters/process_model_execution_adapter.ts
+++ b/src/adapters/process_model_execution_adapter.ts
@@ -42,6 +42,7 @@ export class ProcessModelExecutionAdapter implements IProcessModelExecutionAdapt
     }
 
     if (!Object.values(DataModels.ProcessModels.StartCallbackType).includes(startCallbackType)) {
+      console.log(JSON.stringify(startCallbackType));
       throw new EssentialProjectErrors.BadRequestError(`${startCallbackType} is not a valid return option!`);
     }
 
@@ -88,7 +89,7 @@ export class ProcessModelExecutionAdapter implements IProcessModelExecutionAdapt
 
       processEndedMessage = await this
         ._executeProcessService
-        .startAndAwaitSpecificEndEvent(identity, processModelId, correlationId, endEventId, payload.inputValues, startEventId, payload.callerId);
+        .startAndAwaitSpecificEndEvent(identity, processModelId, correlationId, endEventId, startEventId, payload.inputValues, payload.callerId);
 
       response.endEventId = processEndedMessage.flowNodeId;
       response.tokenPayload = processEndedMessage.currentToken;

--- a/src/adapters/process_model_execution_adapter.ts
+++ b/src/adapters/process_model_execution_adapter.ts
@@ -11,12 +11,13 @@ import {
 import * as uuid from 'node-uuid';
 
 export interface IProcessModelExecutionAdapter {
-  startProcessInstance(identity: IIdentity,
-                       processModelId: string,
-                       payload: DataModels.ProcessModels.ProcessStartRequestPayload,
-                       startCallbackType: DataModels.ProcessModels.StartCallbackType,
-                       startEventId?: string,
-                       endEventId?: string): Promise<DataModels.ProcessModels.ProcessStartResponsePayload>;
+  startProcessInstance(
+    identity: IIdentity,
+    processModelId: string,
+    payload: DataModels.ProcessModels.ProcessStartRequestPayload,
+    startCallbackType: DataModels.ProcessModels.StartCallbackType,
+    startEventId?: string,
+    endEventId?: string): Promise<DataModels.ProcessModels.ProcessStartResponsePayload>;
 }
 
 export class ProcessModelExecutionAdapter implements IProcessModelExecutionAdapter {

--- a/src/adapters/process_model_execution_adapter.ts
+++ b/src/adapters/process_model_execution_adapter.ts
@@ -42,7 +42,6 @@ export class ProcessModelExecutionAdapter implements IProcessModelExecutionAdapt
     }
 
     if (!Object.values(DataModels.ProcessModels.StartCallbackType).includes(startCallbackType)) {
-      console.log(JSON.stringify(startCallbackType));
       throw new EssentialProjectErrors.BadRequestError(`${startCallbackType} is not a valid return option!`);
     }
 

--- a/src/adapters/process_model_execution_adapter.ts
+++ b/src/adapters/process_model_execution_adapter.ts
@@ -72,17 +72,8 @@ export class ProcessModelExecutionAdapter implements IProcessModelExecutionAdapt
     // Only start the process instance and return
     const resolveImmediatelyAfterStart: boolean = startCallbackType === DataModels.ProcessModels.StartCallbackType.CallbackOnProcessInstanceCreated;
     if (resolveImmediatelyAfterStart) {
-<<<<<<< HEAD
       const startResult: ProcessStartedMessage =
         await this._executeProcessService.start(identity, processModelId, startEventId, correlationId, payload.inputValues, payload.callerId);
-=======
-      const startResult: ProcessStartedMessage = await this.executeProcessService.start(identity,
-                                                                                        processModel,
-                                                                                        correlationId,
-                                                                                        startEventId,
-                                                                                        payload.inputValues,
-                                                                                        payload.callerId);
->>>>>>> :bug: Fix Wrong Parameters
 
       response.processInstanceId = startResult.processInstanceId;
 

--- a/src/consumer_api_service.ts
+++ b/src/consumer_api_service.ts
@@ -235,15 +235,15 @@ export class ConsumerApiService implements IConsumerApi {
   public async startProcessInstance(
     identity: IIdentity,
     processModelId: string,
-    startEventId: string,
     payload: DataModels.ProcessModels.ProcessStartRequestPayload,
     startCallbackType?: DataModels.ProcessModels.StartCallbackType,
+    startEventId?: string,
     endEventId?: string,
   ): Promise<DataModels.ProcessModels.ProcessStartResponsePayload> {
 
     return this
       ._processModelExecutionAdapter
-      .startProcessInstance(identity, processModelId, startEventId, payload, startCallbackType, endEventId);
+      .startProcessInstance(identity, processModelId, payload, startCallbackType, startEventId, endEventId);
   }
 
   public async getProcessResultForCorrelation(


### PR DESCRIPTION
**Changes:**

1. Makes the StartEventId Parameter on the `startProcessInstance` UseCases optional.
This is a breaking change, because the public methods of the client and its accessors have been changed.

**Issues:**

Related: https://github.com/process-engine/process_engine_runtime/issues/252

PR: #87 

## How can others test the changes?

* Run the integration Tests for the ConsumerApi

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).

