### PR TITLE
🐛 Fix the retrieval of correlation results

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/consumer_api_core",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "the api-package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
**Changes:**

This fixes the `getProcessResultForCorrelation` function and allows it to correctly retrieve results from multiple EndEvents within a correlation.

**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/266

PR: #88

## How can others test the changes?

- Execute [this ProcessModel](https://github.com/process-engine/consumer_api_core/files/2889485/test_consumer_api_correlation_multiple_results.bpmn.zip).
- Use the Consumer API's `getProcessResultForCorrelation` function to get all results for this ProcessModel.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).