### PR TITLE
✨Additional notifications for activities

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
   "homepage": "https://github.com/process-engine/consumer_api#readme",
   "dependencies": {
     "@essential-projects/errors_ts": "^1.5.0",
-    "@process-engine/consumer_api_contracts": "7.0.0-f7e1f918-b14",
+    "@process-engine/consumer_api_contracts": "feature~additional_notifications_for_activities",
     "@process-engine/correlation.contracts": "^2.0.0",
     "@process-engine/flow_node_instance.contracts": "^2.0.0",
-    "@process-engine/process_engine_contracts": "^44.0.0",
+    "@process-engine/process_engine_contracts": "feature~additional_notifications_for_activities",
     "@process-engine/process_model.contracts": "^2.3.0",
     "bluebird": "~3.5.2",
     "bluebird-global": "~1.0.1",

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
   "homepage": "https://github.com/process-engine/consumer_api#readme",
   "dependencies": {
     "@essential-projects/errors_ts": "^1.5.0",
-    "@process-engine/consumer_api_contracts": "feature~additional_notifications_for_activities",
+    "@process-engine/consumer_api_contracts": "7.0.0-8393af71-b15",
     "@process-engine/correlation.contracts": "^2.0.0",
     "@process-engine/flow_node_instance.contracts": "^2.0.0",
-    "@process-engine/process_engine_contracts": "feature~additional_notifications_for_activities",
+    "@process-engine/process_engine_contracts": "45.0.0-4cd02bdc-b11",
     "@process-engine/process_model.contracts": "^2.3.0",
     "bluebird": "~3.5.2",
     "bluebird-global": "~1.0.1",

--- a/src/adapters/notification_adapter.ts
+++ b/src/adapters/notification_adapter.ts
@@ -32,7 +32,7 @@ export class NotificationAdapter {
     subscribeOnce: boolean,
   ): Subscription {
 
-    const eventName = Messages.EventAggregatorSettings.messagePaths.callActivityReached;
+    const eventName = Messages.EventAggregatorSettings.messagePaths.activityReached;
 
     const sanitationCallback = (message: ActivityReachedMessage): void => {
       const sanitizedMessage = this.sanitizeMessage(message);
@@ -48,7 +48,7 @@ export class NotificationAdapter {
     subscribeOnce: boolean,
   ): Subscription {
 
-    const eventName = Messages.EventAggregatorSettings.messagePaths.callActivityFinished;
+    const eventName = Messages.EventAggregatorSettings.messagePaths.activityFinished;
 
     const sanitationCallback = (message: ActivityFinishedMessage): void => {
       const sanitizedMessage = this.sanitizeMessage(message);

--- a/src/adapters/notification_adapter.ts
+++ b/src/adapters/notification_adapter.ts
@@ -58,6 +58,48 @@ export class NotificationAdapter {
     return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
   }
 
+  // ------------ For backwards compatibility only
+
+  public async onCallActivityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnCallActivityWaitingCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.activityReached;
+
+    const sanitationCallback = (message: ActivityReachedMessage): void => {
+
+      // TODO - Check if the message is for a callActivity
+
+      const sanitizedMessage = this.sanitizeMessage(message);
+      callback(sanitizedMessage);
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  public async onCallActivityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnCallActivityFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.activityFinished;
+
+    const sanitationCallback = (message: ActivityFinishedMessage): void => {
+
+      // TODO - Check if the message is for a callActivity
+
+      const sanitizedMessage = this.sanitizeMessage(message);
+      callback(sanitizedMessage);
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  // ------------
+
   public onEmptyActivityWaiting(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnEmptyActivityWaitingCallback,

--- a/src/adapters/notification_adapter.ts
+++ b/src/adapters/notification_adapter.ts
@@ -7,6 +7,7 @@ import {
   ActivityReachedMessage,
   BaseSystemEventMessage,
   BoundaryEventTriggeredMessage,
+  BpmnType,
   EndEventReachedMessage,
   IntermediateCatchEventFinishedMessage,
   IntermediateCatchEventReachedMessage,
@@ -35,7 +36,10 @@ export class NotificationAdapter {
     const eventName = Messages.EventAggregatorSettings.messagePaths.activityReached;
 
     const sanitationCallback = (message: ActivityReachedMessage): void => {
-      const sanitizedMessage = this.sanitizeMessage(message);
+      const sanitizedMessage = this.sanitizeMessage<ActivityReachedMessage>(message);
+
+      sanitizedMessage.flowNodeType = message.flowNodeType;
+
       callback(sanitizedMessage);
     };
 
@@ -51,7 +55,10 @@ export class NotificationAdapter {
     const eventName = Messages.EventAggregatorSettings.messagePaths.activityFinished;
 
     const sanitationCallback = (message: ActivityFinishedMessage): void => {
-      const sanitizedMessage = this.sanitizeMessage(message);
+      const sanitizedMessage = this.sanitizeMessage<ActivityFinishedMessage>(message);
+
+      sanitizedMessage.flowNodeType = message.flowNodeType;
+
       callback(sanitizedMessage);
     };
 
@@ -70,9 +77,14 @@ export class NotificationAdapter {
 
     const sanitationCallback = (message: ActivityReachedMessage): void => {
 
-      // TODO - Check if the message is for a callActivity
+      if (message.flowNodeType !== BpmnType.callActivity) {
+        return;
+      }
 
-      const sanitizedMessage = this.sanitizeMessage(message);
+      const sanitizedMessage = this.sanitizeMessage<ActivityReachedMessage>(message);
+
+      sanitizedMessage.flowNodeType = message.flowNodeType;
+
       callback(sanitizedMessage);
     };
 
@@ -89,9 +101,14 @@ export class NotificationAdapter {
 
     const sanitationCallback = (message: ActivityFinishedMessage): void => {
 
-      // TODO - Check if the message is for a callActivity
+      if (message.flowNodeType !== BpmnType.callActivity) {
+        return;
+      }
 
-      const sanitizedMessage = this.sanitizeMessage(message);
+      const sanitizedMessage = this.sanitizeMessage<ActivityFinishedMessage>(message);
+
+      sanitizedMessage.flowNodeType = message.flowNodeType;
+
       callback(sanitizedMessage);
     };
 

--- a/src/adapters/notification_adapter.ts
+++ b/src/adapters/notification_adapter.ts
@@ -3,18 +3,14 @@ import {IIdentity} from '@essential-projects/iam_contracts';
 import {Messages} from '@process-engine/consumer_api_contracts';
 
 import {
+  ActivityFinishedMessage,
+  ActivityReachedMessage,
   BaseSystemEventMessage,
   BoundaryEventTriggeredMessage,
-  CallActivityFinishedMessage,
-  CallActivityReachedMessage,
-  EmptyActivityFinishedMessage,
-  EmptyActivityReachedMessage,
   EndEventReachedMessage,
   IntermediateCatchEventFinishedMessage,
   IntermediateCatchEventReachedMessage,
   IntermediateThrowEventTriggeredMessage,
-  ManualTaskFinishedMessage,
-  ManualTaskReachedMessage,
   ProcessErrorMessage,
   ProcessStartedMessage,
   TerminateEndEventReachedMessage,
@@ -30,6 +26,38 @@ export class NotificationAdapter {
     this.eventAggregator = eventAggregator;
   }
 
+  public onActivityReached(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnActivityReachedCallback,
+    subscribeOnce: boolean,
+  ): Subscription {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.callActivityReached;
+
+    const sanitationCallback = (message: ActivityReachedMessage): void => {
+      const sanitizedMessage = this.sanitizeMessage(message);
+      callback(sanitizedMessage);
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
+  public onActivityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnActivityFinishedCallback,
+    subscribeOnce: boolean,
+  ): Subscription {
+
+    const eventName = Messages.EventAggregatorSettings.messagePaths.callActivityFinished;
+
+    const sanitationCallback = (message: ActivityFinishedMessage): void => {
+      const sanitizedMessage = this.sanitizeMessage(message);
+      callback(sanitizedMessage);
+    };
+
+    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
+  }
+
   public onEmptyActivityWaiting(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnEmptyActivityWaitingCallback,
@@ -38,7 +66,7 @@ export class NotificationAdapter {
 
     const eventName = Messages.EventAggregatorSettings.messagePaths.emptyActivityReached;
 
-    const sanitationCallback = (message: EmptyActivityReachedMessage): void => {
+    const sanitationCallback = (message: ActivityFinishedMessage): void => {
       const sanitizedMessage = this.sanitizeMessage(message);
       callback(sanitizedMessage);
     };
@@ -54,7 +82,7 @@ export class NotificationAdapter {
 
     const eventName = Messages.EventAggregatorSettings.messagePaths.emptyActivityFinished;
 
-    const sanitationCallback = (message: EmptyActivityFinishedMessage): void => {
+    const sanitationCallback = (message: ActivityReachedMessage): void => {
       const sanitizedMessage = this.sanitizeMessage(message);
       callback(sanitizedMessage);
     };
@@ -70,7 +98,7 @@ export class NotificationAdapter {
 
     const eventName = Messages.EventAggregatorSettings.messagePaths.emptyActivityReached;
 
-    const sanitationCallback = (message: EmptyActivityReachedMessage): void => {
+    const sanitationCallback = (message: ActivityFinishedMessage): void => {
 
       const identitiesMatch = this.checkIfIdentityUserIDsMatch(identity, message.processInstanceOwner);
       if (identitiesMatch) {
@@ -90,7 +118,7 @@ export class NotificationAdapter {
 
     const eventName = Messages.EventAggregatorSettings.messagePaths.emptyActivityFinished;
 
-    const sanitationCallback = (message: EmptyActivityFinishedMessage): void => {
+    const sanitationCallback = (message: ActivityReachedMessage): void => {
 
       const identitiesMatch = this.checkIfIdentityUserIDsMatch(identity, message.processInstanceOwner);
       if (identitiesMatch) {
@@ -176,7 +204,7 @@ export class NotificationAdapter {
 
     const eventName = Messages.EventAggregatorSettings.messagePaths.manualTaskReached;
 
-    const sanitationCallback = (message: ManualTaskReachedMessage): void => {
+    const sanitationCallback = (message: ActivityReachedMessage): void => {
       const sanitizedMessage = this.sanitizeMessage(message);
       callback(sanitizedMessage);
     };
@@ -192,7 +220,7 @@ export class NotificationAdapter {
 
     const eventName = Messages.EventAggregatorSettings.messagePaths.manualTaskFinished;
 
-    const sanitationCallback = (message: ManualTaskFinishedMessage): void => {
+    const sanitationCallback = (message: ActivityReachedMessage): void => {
       const sanitizedMessage = this.sanitizeMessage(message);
       callback(sanitizedMessage);
     };
@@ -208,7 +236,7 @@ export class NotificationAdapter {
 
     const eventName = Messages.EventAggregatorSettings.messagePaths.manualTaskReached;
 
-    const sanitationCallback = (message: ManualTaskReachedMessage): void => {
+    const sanitationCallback = (message: ActivityReachedMessage): void => {
 
       const identitiesMatch = this.checkIfIdentityUserIDsMatch(identity, message.processInstanceOwner);
       if (identitiesMatch) {
@@ -228,45 +256,13 @@ export class NotificationAdapter {
 
     const eventName = Messages.EventAggregatorSettings.messagePaths.manualTaskFinished;
 
-    const sanitationCallback = (message: ManualTaskFinishedMessage): void => {
+    const sanitationCallback = (message: ActivityReachedMessage): void => {
 
       const identitiesMatch = this.checkIfIdentityUserIDsMatch(identity, message.processInstanceOwner);
       if (identitiesMatch) {
         const sanitizedMessage = this.sanitizeMessage(message);
         callback(sanitizedMessage);
       }
-    };
-
-    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
-  }
-
-  public onCallActivityWaiting(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnCallActivityWaitingCallback,
-    subscribeOnce: boolean,
-  ): Subscription {
-
-    const eventName = Messages.EventAggregatorSettings.messagePaths.callActivityReached;
-
-    const sanitationCallback = (message: CallActivityReachedMessage): void => {
-      const sanitizedMessage = this.sanitizeMessage(message);
-      callback(sanitizedMessage);
-    };
-
-    return this.createSubscription(eventName, sanitationCallback, subscribeOnce);
-  }
-
-  public onCallActivityFinished(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnCallActivityFinishedCallback,
-    subscribeOnce: boolean,
-  ): Subscription {
-
-    const eventName = Messages.EventAggregatorSettings.messagePaths.callActivityFinished;
-
-    const sanitationCallback = (message: CallActivityFinishedMessage): void => {
-      const sanitizedMessage = this.sanitizeMessage(message);
-      callback(sanitizedMessage);
     };
 
     return this.createSubscription(eventName, sanitationCallback, subscribeOnce);

--- a/src/consumer_api_service.ts
+++ b/src/consumer_api_service.ts
@@ -12,11 +12,10 @@ import {
 } from '@process-engine/flow_node_instance.contracts';
 import {
   IProcessModelFacadeFactory,
-  EmptyActivityFinishedMessage as InternalEmptyActivityFinishedMessage,
+  ActivityFinishedMessage as InternalActivityFinishedMessage,
   FinishEmptyActivityMessage as InternalFinishEmptyActivityMessage,
   FinishManualTaskMessage as InternalFinishManualTaskMessage,
   FinishUserTaskMessage as InternalFinishUserTaskMessage,
-  ManualTaskFinishedMessage as InternalManualTaskFinishedMessage,
   UserTaskFinishedMessage as InternalUserTaskFinishedMessage,
 } from '@process-engine/process_engine_contracts';
 import {IProcessModelUseCases, Model} from '@process-engine/process_model.contracts';
@@ -86,6 +85,26 @@ export class ConsumerApiService implements IConsumerApi {
   }
 
   // Notifications
+  public async onActivityReached(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnActivityReachedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onActivityReached(identity, callback, subscribeOnce);
+  }
+
+  public async onActivityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnActivityFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onActivityFinished(identity, callback, subscribeOnce);
+  }
+
   public async onEmptyActivityWaiting(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnEmptyActivityWaitingCallback,
@@ -204,26 +223,6 @@ export class ConsumerApiService implements IConsumerApi {
     await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
 
     return this.notificationAdapter.onIntermediateThrowEventTriggered(identity, callback, subscribeOnce);
-  }
-
-  public async onCallActivityWaiting(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnCallActivityWaitingCallback,
-    subscribeOnce: boolean = false,
-  ): Promise<Subscription> {
-    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
-
-    return this.notificationAdapter.onCallActivityWaiting(identity, callback, subscribeOnce);
-  }
-
-  public async onCallActivityFinished(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnCallActivityFinishedCallback,
-    subscribeOnce: boolean = false,
-  ): Promise<Subscription> {
-    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
-
-    return this.notificationAdapter.onCallActivityFinished(identity, callback, subscribeOnce);
   }
 
   public async onManualTaskWaiting(
@@ -597,7 +596,7 @@ export class ConsumerApiService implements IConsumerApi {
         .replace(routePrameter.processInstanceId, processInstanceId)
         .replace(routePrameter.flowNodeInstanceId, emptyActivityInstanceId);
 
-      this.eventAggregator.subscribeOnce(emptyActivityFinishedEvent, (message: InternalEmptyActivityFinishedMessage): void => {
+      this.eventAggregator.subscribeOnce(emptyActivityFinishedEvent, (message: InternalActivityFinishedMessage): void => {
         resolve();
       });
 
@@ -693,7 +692,7 @@ export class ConsumerApiService implements IConsumerApi {
         .replace(routePrameter.processInstanceId, processInstanceId)
         .replace(routePrameter.flowNodeInstanceId, manualTaskInstanceId);
 
-      this.eventAggregator.subscribeOnce(manualTaskFinishedEvent, (message: InternalManualTaskFinishedMessage): void => {
+      this.eventAggregator.subscribeOnce(manualTaskFinishedEvent, (message: InternalActivityFinishedMessage): void => {
         resolve();
       });
 

--- a/src/consumer_api_service.ts
+++ b/src/consumer_api_service.ts
@@ -105,6 +105,30 @@ export class ConsumerApiService implements IConsumerApi {
     return this.notificationAdapter.onActivityFinished(identity, callback, subscribeOnce);
   }
 
+  // ------------ For backwards compatibility only
+
+  public async onCallActivityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnCallActivityWaitingCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onCallActivityWaiting(identity, callback, subscribeOnce);
+  }
+
+  public async onCallActivityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnCallActivityFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+
+    return this.notificationAdapter.onCallActivityFinished(identity, callback, subscribeOnce);
+  }
+
+  // ------------
+
   public async onEmptyActivityWaiting(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnEmptyActivityWaitingCallback,


### PR DESCRIPTION
## Changes

1. Refactor notification subscriptions `onCallActivityWaiting` to `onActivityReached` and `onCallActivityFinished` to `onActivityFinished`.
2. Generalize activity subscription paths, messages and types.
    - This will allow the user to susbcribe to notifications about more than just CallActivities, but also ScriptTasks, SendTasks, ReceiveTasks, ServiceTasks and Subprocesses.
3. Mark `onCallActivityWaiting` and `onCallActivityFinished` as deprecated.
    - The notifications will be removed with the next major release, to give people time to properly adjust their usage of the notifications.

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/349

PR: #95

## How to test the changes

- Create Subscriptions for `onActivityReached` and `onActivityFinished`
- The corresponding callbacks will be triggered, when any kind of activity is reached or finished

