### PR TITLE
♻️ Use contracts from persistence_api.contracts

### DIFF
--- a/ioc_module.js
+++ b/ioc_module.js
@@ -75,7 +75,7 @@ function registerServices(container) {
     .singleton();
 
   container.register('ConsumerApiExternalTaskService', ExternalTaskService)
-    .dependencies('EventAggregator', 'ExternalTaskRepository', 'IamService')
+    .dependencies('EventAggregator', 'ExternalTaskService')
     .singleton();
 
   container

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.5.0",
     "@process-engine/consumer_api_contracts": "^9.0.0",
-    "@process-engine/persistence_api.contracts": "1.0.0-alpha.3",
+    "@process-engine/persistence_api.contracts": "1.0.0-alpha.6",
     "@process-engine/process_engine_contracts": "^46.0.0",
     "bluebird": "~3.5.2",
     "bluebird-global": "~1.0.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.5.0",
     "@process-engine/consumer_api_contracts": "^9.0.0",
-    "@process-engine/persistence_api.contracts": "1.0.0-alpha.6",
+    "@process-engine/persistence_api.contracts": "^1.0.0",
     "@process-engine/process_engine_contracts": "^46.0.0",
     "bluebird": "~3.5.2",
     "bluebird-global": "~1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/consumer_api_core",
-  "version": "6.1.0-alpha.5",
+  "version": "6.2.0",
   "description": "the api-package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
@@ -30,10 +30,8 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.5.0",
     "@process-engine/consumer_api_contracts": "^9.0.0",
-    "@process-engine/correlation.contracts": "^3.0.0",
-    "@process-engine/flow_node_instance.contracts": "^2.1.0",
+    "@process-engine/persistence_api.contracts": "1.0.0-alpha.3",
     "@process-engine/process_engine_contracts": "^46.0.0",
-    "@process-engine/process_model.contracts": "^2.7.0",
     "bluebird": "~3.5.2",
     "bluebird-global": "~1.0.1",
     "loggerhythm": "~3.0.3",

--- a/src/converters/empty_activity_converter.ts
+++ b/src/converters/empty_activity_converter.ts
@@ -1,10 +1,15 @@
 import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {DataModels} from '@process-engine/consumer_api_contracts';
-import {ICorrelationService} from '@process-engine/correlation.contracts';
-import {FlowNodeInstance, ProcessTokenType} from '@process-engine/flow_node_instance.contracts';
+import {
+  BpmnType,
+  FlowNodeInstance,
+  ICorrelationService,
+  IProcessModelUseCases,
+  Model,
+  ProcessTokenType,
+} from '@process-engine/persistence_api.contracts';
 import {IProcessModelFacade, IProcessModelFacadeFactory} from '@process-engine/process_engine_contracts';
-import {BpmnType, IProcessModelUseCases, Model} from '@process-engine/process_model.contracts';
 
 import * as ProcessModelCache from './process_model_cache';
 

--- a/src/converters/event_converter.ts
+++ b/src/converters/event_converter.ts
@@ -3,10 +3,13 @@ import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {InternalServerError} from '@essential-projects/errors_ts';
 import {DataModels} from '@process-engine/consumer_api_contracts';
-import {ICorrelationService} from '@process-engine/correlation.contracts';
-import {FlowNodeInstance} from '@process-engine/flow_node_instance.contracts';
+import {
+  FlowNodeInstance,
+  ICorrelationService,
+  IProcessModelUseCases,
+  Model,
+} from '@process-engine/persistence_api.contracts';
 import {IProcessModelFacade, IProcessModelFacadeFactory} from '@process-engine/process_engine_contracts';
-import {IProcessModelUseCases, Model} from '@process-engine/process_model.contracts';
 
 import * as ProcessModelCache from './process_model_cache';
 

--- a/src/converters/manual_task_converter.ts
+++ b/src/converters/manual_task_converter.ts
@@ -1,10 +1,15 @@
 import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {DataModels} from '@process-engine/consumer_api_contracts';
-import {ICorrelationService} from '@process-engine/correlation.contracts';
-import {FlowNodeInstance, ProcessTokenType} from '@process-engine/flow_node_instance.contracts';
+import {
+  BpmnType,
+  FlowNodeInstance,
+  ICorrelationService,
+  IProcessModelUseCases,
+  Model,
+  ProcessTokenType,
+} from '@process-engine/persistence_api.contracts';
 import {IProcessModelFacade, IProcessModelFacadeFactory} from '@process-engine/process_engine_contracts';
-import {BpmnType, IProcessModelUseCases, Model} from '@process-engine/process_model.contracts';
 
 import * as ProcessModelCache from './process_model_cache';
 

--- a/src/converters/process_model_cache.ts
+++ b/src/converters/process_model_cache.ts
@@ -1,4 +1,4 @@
-import {Model} from '@process-engine/process_model.contracts';
+import {Model} from '@process-engine/persistence_api.contracts';
 
 /**
  * Used to cache ProcessModels during conversion of suspended FlowNodeInstances.

--- a/src/converters/user_task_converter.ts
+++ b/src/converters/user_task_converter.ts
@@ -2,17 +2,22 @@
 import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {DataModels} from '@process-engine/consumer_api_contracts';
-import {ICorrelationService} from '@process-engine/correlation.contracts';
 import {
-  FlowNodeInstance, IFlowNodeInstanceService, ProcessToken, ProcessTokenType,
-} from '@process-engine/flow_node_instance.contracts';
+  BpmnType,
+  FlowNodeInstance,
+  ICorrelationService,
+  IFlowNodeInstanceService,
+  IProcessModelUseCases,
+  Model,
+  ProcessToken,
+  ProcessTokenType,
+} from '@process-engine/persistence_api.contracts';
 import {
   IFlowNodeInstanceResult,
   IProcessModelFacade,
   IProcessModelFacadeFactory,
   IProcessTokenFacadeFactory,
 } from '@process-engine/process_engine_contracts';
-import {BpmnType, IProcessModelUseCases, Model} from '@process-engine/process_model.contracts';
 
 import * as ProcessModelCache from './process_model_cache';
 

--- a/src/empty_activity_service.ts
+++ b/src/empty_activity_service.ts
@@ -6,7 +6,7 @@ import {
   FlowNodeInstance,
   FlowNodeInstanceState,
   IFlowNodeInstanceService,
-} from '@process-engine/flow_node_instance.contracts';
+} from '@process-engine/persistence_api.contracts';
 import {FinishEmptyActivityMessage as InternalFinishEmptyActivityMessage} from '@process-engine/process_engine_contracts';
 
 import {NotificationAdapter} from './adapters/index';

--- a/src/event_service.ts
+++ b/src/event_service.ts
@@ -1,8 +1,7 @@
 import {IEventAggregator} from '@essential-projects/event_aggregator_contracts';
 import {IIAMService, IIdentity} from '@essential-projects/iam_contracts';
 import {APIs, DataModels, Messages} from '@process-engine/consumer_api_contracts';
-import {FlowNodeInstance, IFlowNodeInstanceService} from '@process-engine/flow_node_instance.contracts';
-import {IProcessModelUseCases} from '@process-engine/process_model.contracts';
+import {FlowNodeInstance, IFlowNodeInstanceService, IProcessModelUseCases} from '@process-engine/persistence_api.contracts';
 
 import {EventConverter} from './converters/index';
 import {applyPagination} from './paginator';

--- a/src/external_task_service.ts
+++ b/src/external_task_service.ts
@@ -4,29 +4,25 @@ import * as moment from 'moment';
 
 import * as EssentialProjectErrors from '@essential-projects/errors_ts';
 import {IEventAggregator, Subscription} from '@essential-projects/event_aggregator_contracts';
-import {IIAMService, IIdentity} from '@essential-projects/iam_contracts';
+import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {
   APIs,
   DataModels,
-  IExternalTaskRepository,
   Messages,
 } from '@process-engine/consumer_api_contracts';
+import {IExternalTaskService} from '@process-engine/persistence_api.contracts';
 
 const logger = new Logger('processengine:consumer_api:external_task_service');
 
 export class ExternalTaskService implements APIs.IExternalTaskConsumerApi {
 
   private readonly eventAggregator: IEventAggregator;
-  private readonly externalTaskRepository: IExternalTaskRepository;
-  private readonly iamService: IIAMService;
+  private readonly externalTaskService: IExternalTaskService;
 
-  private readonly canAccessExternalTasksClaim = 'can_access_external_tasks';
-
-  constructor(eventAggregator: IEventAggregator, externalTaskRepository: IExternalTaskRepository, iamService: IIAMService) {
+  constructor(eventAggregator: IEventAggregator, externalTaskService: IExternalTaskService) {
     this.eventAggregator = eventAggregator;
-    this.externalTaskRepository = externalTaskRepository;
-    this.iamService = iamService;
+    this.externalTaskService = externalTaskService;
   }
 
   public async fetchAndLockExternalTasks<TPayload>(
@@ -38,16 +34,14 @@ export class ExternalTaskService implements APIs.IExternalTaskConsumerApi {
     lockDuration: number,
   ): Promise<Array<DataModels.ExternalTask.ExternalTask<TPayload>>> {
 
-    await this.iamService.ensureHasClaim(identity, this.canAccessExternalTasksClaim);
-
-    const tasks = await this.fetchOrWaitForExternalTasks<TPayload>(topicName, maxTasks, longPollingTimeout);
+    const tasks = await this.fetchOrWaitForExternalTasks<TPayload>(identity, topicName, maxTasks, longPollingTimeout);
 
     const lockExpirationTime = this.getLockExpirationDate(lockDuration);
 
     const lockedTasks = await Promise.map(
       tasks,
       async (externalTask: DataModels.ExternalTask.ExternalTask<TPayload>): Promise<DataModels.ExternalTask.ExternalTask<TPayload>> => {
-        return this.lockExternalTask(externalTask, workerId, lockExpirationTime);
+        return this.lockExternalTask(identity, externalTask, workerId, lockExpirationTime);
       },
     );
 
@@ -59,30 +53,26 @@ export class ExternalTaskService implements APIs.IExternalTaskConsumerApi {
 
   public async extendLock(identity: IIdentity, workerId: string, externalTaskId: string, additionalDuration: number): Promise<void> {
 
-    await this.iamService.ensureHasClaim(identity, this.canAccessExternalTasksClaim);
-
     // Note: The type of the initial payload is irrelevant for lock extension.
-    const externalTask = await this.externalTaskRepository.getById(externalTaskId);
+    const externalTask = await this.externalTaskService.getById(identity, externalTaskId);
 
     this.ensureExternalTaskCanBeAccessedByWorker(externalTask, externalTaskId, workerId);
 
     const newLockExpirationTime = this.getLockExpirationDate(additionalDuration);
 
-    return this.externalTaskRepository.lockForWorker(workerId, externalTaskId, newLockExpirationTime);
+    return this.externalTaskService.lockForWorker(identity, workerId, externalTaskId, newLockExpirationTime);
   }
 
   public async handleBpmnError(identity: IIdentity, workerId: string, externalTaskId: string, errorCode: string): Promise<void> {
 
-    await this.iamService.ensureHasClaim(identity, this.canAccessExternalTasksClaim);
-
     // Note: The type of the initial payload is irrelevant for finishing with an error.
-    const externalTask = await this.externalTaskRepository.getById(externalTaskId);
+    const externalTask = await this.externalTaskService.getById(identity, externalTaskId);
 
     this.ensureExternalTaskCanBeAccessedByWorker(externalTask, externalTaskId, workerId);
 
     const error = new EssentialProjectErrors.InternalServerError(`ExternalTask failed due to BPMN error with code ${errorCode}`);
 
-    await this.externalTaskRepository.finishWithError(externalTaskId, error);
+    await this.externalTaskService.finishWithError(identity, externalTaskId, error);
 
     const errorNotificationPayload = new Messages.SystemEvents.ExternalTaskErrorMessage(error);
 
@@ -97,16 +87,14 @@ export class ExternalTaskService implements APIs.IExternalTaskConsumerApi {
     errorDetails: string,
   ): Promise<void> {
 
-    await this.iamService.ensureHasClaim(identity, this.canAccessExternalTasksClaim);
-
-    const externalTask = await this.externalTaskRepository.getById(externalTaskId);
+    const externalTask = await this.externalTaskService.getById(identity, externalTaskId);
 
     this.ensureExternalTaskCanBeAccessedByWorker(externalTask, externalTaskId, workerId);
 
     const error = new EssentialProjectErrors.InternalServerError(errorMessage);
     error.additionalInformation = errorDetails;
 
-    await this.externalTaskRepository.finishWithError(externalTaskId, error);
+    await this.externalTaskService.finishWithError(identity, externalTaskId, error);
 
     const errorNotificationPayload = new Messages.SystemEvents.ExternalTaskErrorMessage(error);
 
@@ -120,13 +108,11 @@ export class ExternalTaskService implements APIs.IExternalTaskConsumerApi {
     payload: TResultType,
   ): Promise<void> {
 
-    await this.iamService.ensureHasClaim(identity, this.canAccessExternalTasksClaim);
-
-    const externalTask = await this.externalTaskRepository.getById(externalTaskId);
+    const externalTask = await this.externalTaskService.getById(identity, externalTaskId);
 
     this.ensureExternalTaskCanBeAccessedByWorker(externalTask, externalTaskId, workerId);
 
-    await this.externalTaskRepository.finishWithSuccess<TResultType>(externalTaskId, payload);
+    await this.externalTaskService.finishWithSuccess<TResultType>(identity, externalTaskId, payload);
 
     const successNotificationPayload = new Messages.SystemEvents.ExternalTaskSuccessMessage(payload);
 
@@ -134,6 +120,7 @@ export class ExternalTaskService implements APIs.IExternalTaskConsumerApi {
   }
 
   private async fetchOrWaitForExternalTasks<TPayload>(
+    identity: IIdentity,
     topicName: string,
     maxTasks: number,
     longPollingTimeout: number,
@@ -142,7 +129,7 @@ export class ExternalTaskService implements APIs.IExternalTaskConsumerApi {
     // eslint-disable-next-line consistent-return
     return new Promise<Array<DataModels.ExternalTask.ExternalTask<TPayload>>>(async (resolve: Function): Promise<void> => {
 
-      const tasks = await this.externalTaskRepository.fetchAvailableForProcessing<TPayload>(topicName, maxTasks);
+      const tasks = await this.externalTaskService.fetchAvailableForProcessing<TPayload>(identity, topicName, maxTasks);
 
       const taskAreNotEmpty = tasks.length > 0;
 
@@ -163,7 +150,7 @@ export class ExternalTaskService implements APIs.IExternalTaskConsumerApi {
 
         clearTimeout(timeout);
 
-        const availableTasks = await this.externalTaskRepository.fetchAvailableForProcessing<TPayload>(topicName, maxTasks);
+        const availableTasks = await this.externalTaskService.fetchAvailableForProcessing<TPayload>(identity, topicName, maxTasks);
 
         return resolve(availableTasks);
       });
@@ -182,13 +169,14 @@ export class ExternalTaskService implements APIs.IExternalTaskConsumerApi {
    * @returns                  The clocked ExternalTask.
    */
   private async lockExternalTask<TPayload>(
+    identity: IIdentity,
     externalTask: DataModels.ExternalTask.ExternalTask<TPayload>,
     workerId: string,
     lockExpirationTime: Date,
   ): Promise<DataModels.ExternalTask.ExternalTask<TPayload>> {
 
     try {
-      await this.externalTaskRepository.lockForWorker(workerId, externalTask.id, lockExpirationTime);
+      await this.externalTaskService.lockForWorker(identity, workerId, externalTask.id, lockExpirationTime);
 
       externalTask.workerId = workerId;
       externalTask.lockExpirationTime = lockExpirationTime;

--- a/src/flow_node_instance_service.ts
+++ b/src/flow_node_instance_service.ts
@@ -3,7 +3,7 @@ import {
   FlowNodeInstance,
   FlowNodeInstanceState,
   IFlowNodeInstanceService,
-} from '@process-engine/flow_node_instance.contracts';
+} from '@process-engine/persistence_api.contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {EmptyActivityConverter, ManualTaskConverter, UserTaskConverter} from './converters/index';

--- a/src/manual_task_service.ts
+++ b/src/manual_task_service.ts
@@ -6,7 +6,7 @@ import {
   FlowNodeInstance,
   FlowNodeInstanceState,
   IFlowNodeInstanceService,
-} from '@process-engine/flow_node_instance.contracts';
+} from '@process-engine/persistence_api.contracts';
 import {FinishManualTaskMessage as InternalFinishManualTaskMessage} from '@process-engine/process_engine_contracts';
 
 import {NotificationAdapter} from './adapters/index';

--- a/src/process_model_service.ts
+++ b/src/process_model_service.ts
@@ -8,16 +8,17 @@ import {
   BpmnType,
   FlowNodeInstance,
   IFlowNodeInstanceService,
+  IProcessModelUseCases,
+  Model,
   ProcessToken,
   ProcessTokenType,
-} from '@process-engine/flow_node_instance.contracts';
+} from '@process-engine/persistence_api.contracts';
 import {
   EndEventReachedMessage,
   IExecuteProcessService,
   IProcessModelFacadeFactory,
   ProcessStartedMessage,
 } from '@process-engine/process_engine_contracts';
-import {IProcessModelUseCases, Model} from '@process-engine/process_model.contracts';
 
 import {NotificationAdapter} from './adapters/index';
 import {applyPagination} from './paginator';

--- a/src/user_task_service.ts
+++ b/src/user_task_service.ts
@@ -6,7 +6,7 @@ import {
   FlowNodeInstance,
   FlowNodeInstanceState,
   IFlowNodeInstanceService,
-} from '@process-engine/flow_node_instance.contracts';
+} from '@process-engine/persistence_api.contracts';
 import {FinishUserTaskMessage as InternalFinishUserTaskMessage} from '@process-engine/process_engine_contracts';
 
 import {NotificationAdapter} from './adapters/index';


### PR DESCRIPTION
## Changes

1. Replace the following imports with `persistence_api.contracts`:
- `correlation.contracts`
- `cronjob_history.contracts`
- `flow_node_instance.contracts`
- `process_model.contracts`
2. Use the new `ExternalTaskService` from the runtime layer to access ExternalTasks
3. Remove claim checks from the ConsumerAPI's `ExternalTaskService`, since these are now performed by the runtime's `ExternalTaskService`
4. Fix unhandled Promise-Rejection during `FetchAndLock` operation for ExternalTasks

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/428

PR: #106

## How to test the changes

All should work as before.