### PR TITLE
⚡️ ✨ Add lane and name to flow node instance

### DIFF
--- a/ioc_module.js
+++ b/ioc_module.js
@@ -56,13 +56,10 @@ function registerInContainer(container) {
   container
     .register('ConsumerApiManualTaskService', ManualTaskService)
     .dependencies(
-      'CorrelationService',
       'EventAggregator',
       'FlowNodeInstanceService',
       'IamService',
       'ConsumerApiNotificationAdapter',
-      'ProcessModelFacadeFactory',
-      'ProcessModelUseCases',
     )
     .singleton();
 

--- a/ioc_module.js
+++ b/ioc_module.js
@@ -20,13 +20,10 @@ function registerInContainer(container) {
   container
     .register('ConsumerApiEmptyActivityService', EmptyActivityService)
     .dependencies(
-      'CorrelationService',
       'EventAggregator',
       'FlowNodeInstanceService',
       'IamService',
       'ConsumerApiNotificationAdapter',
-      'ProcessModelFacadeFactory',
-      'ProcessModelUseCases',
     )
     .singleton();
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.5.0",
     "@process-engine/consumer_api_contracts": "^9.0.0",
-    "@process-engine/persistence_api.contracts": "1.1.0-alpha.2",
+    "@process-engine/persistence_api.contracts": "feature~add_lane_and_name_to_flow_node_instance",
     "@process-engine/process_engine_contracts": "^46.0.0",
     "bluebird": "~3.5.2",
     "bluebird-global": "~1.0.1",

--- a/src/empty_activity_service.ts
+++ b/src/empty_activity_service.ts
@@ -90,9 +90,9 @@ export class EmptyActivityService implements APIs.IEmptyActivityConsumerApi {
 
     const accessibleEmptyActivities = await this.filterInacessibleFlowNodeInstances(identity, emptyActivities);
 
-    const emptyActivityList = await this.convertFlowNodeInstancesToEmptyActivities(identity, accessibleEmptyActivities);
+    const emptyActivitiesToReturn = applyPagination(accessibleEmptyActivities, offset, limit);
 
-    emptyActivityList.emptyActivities = applyPagination(emptyActivityList.emptyActivities, offset, limit);
+    const emptyActivityList = this.convertFlowNodeInstancesToEmptyActivities(identity, emptyActivitiesToReturn);
 
     return emptyActivityList;
   }
@@ -110,9 +110,9 @@ export class EmptyActivityService implements APIs.IEmptyActivityConsumerApi {
 
     const accessibleEmptyActivities = await this.filterInacessibleFlowNodeInstances(identity, emptyActivities);
 
-    const emptyActivityList = await this.convertFlowNodeInstancesToEmptyActivities(identity, accessibleEmptyActivities);
+    const emptyActivitiesToReturn = applyPagination(accessibleEmptyActivities, offset, limit);
 
-    emptyActivityList.emptyActivities = applyPagination(emptyActivityList.emptyActivities, offset, limit);
+    const emptyActivityList = this.convertFlowNodeInstancesToEmptyActivities(identity, emptyActivitiesToReturn);
 
     return emptyActivityList;
   }
@@ -130,9 +130,9 @@ export class EmptyActivityService implements APIs.IEmptyActivityConsumerApi {
 
     const accessibleEmptyActivities = await this.filterInacessibleFlowNodeInstances(identity, emptyActivities);
 
-    const emptyActivityList = await this.convertFlowNodeInstancesToEmptyActivities(identity, accessibleEmptyActivities);
+    const emptyActivitiesToReturn = applyPagination(accessibleEmptyActivities, offset, limit);
 
-    emptyActivityList.emptyActivities = applyPagination(emptyActivityList.emptyActivities, offset, limit);
+    const emptyActivityList = this.convertFlowNodeInstancesToEmptyActivities(identity, emptyActivitiesToReturn);
 
     return emptyActivityList;
   }
@@ -155,9 +155,9 @@ export class EmptyActivityService implements APIs.IEmptyActivityConsumerApi {
 
     const accessibleEmptyActivities = await this.filterInacessibleFlowNodeInstances(identity, emptyActivities);
 
-    const emptyActivityList = await this.convertFlowNodeInstancesToEmptyActivities(identity, accessibleEmptyActivities);
+    const emptyActivitiesToReturn = applyPagination(accessibleEmptyActivities, offset, limit);
 
-    emptyActivityList.emptyActivities = applyPagination(emptyActivityList.emptyActivities, offset, limit);
+    const emptyActivityList = this.convertFlowNodeInstancesToEmptyActivities(identity, emptyActivitiesToReturn);
 
     return emptyActivityList;
   }
@@ -176,9 +176,9 @@ export class EmptyActivityService implements APIs.IEmptyActivityConsumerApi {
       return isEmptyActivity && userIdsMatch;
     });
 
-    const emptyActivityList = await this.convertFlowNodeInstancesToEmptyActivities(identity, flowNodeInstancesOwnedByUser);
+    const emptyActivitiesToReturn = applyPagination(flowNodeInstancesOwnedByUser, offset, limit);
 
-    emptyActivityList.emptyActivities = applyPagination(emptyActivityList.emptyActivities, offset, limit);
+    const emptyActivityList = this.convertFlowNodeInstancesToEmptyActivities(identity, emptyActivitiesToReturn);
 
     return emptyActivityList;
   }
@@ -223,10 +223,10 @@ export class EmptyActivityService implements APIs.IEmptyActivityConsumerApi {
     });
   }
 
-  public async convertFlowNodeInstancesToEmptyActivities(
+  public convertFlowNodeInstancesToEmptyActivities(
     identity: IIdentity,
     suspendedFlowNodes: Array<FlowNodeInstance>,
-  ): Promise<DataModels.EmptyActivities.EmptyActivityList> {
+  ): DataModels.EmptyActivities.EmptyActivityList {
 
     const suspendedEmptyActivities = suspendedFlowNodes.map(this.convertSuspendedFlowNodeToEmptyActivity);
 

--- a/src/event_service.ts
+++ b/src/event_service.ts
@@ -5,6 +5,7 @@ import {IIAMService, IIdentity} from '@essential-projects/iam_contracts';
 import {APIs, DataModels, Messages} from '@process-engine/consumer_api_contracts';
 import {
   FlowNodeInstance,
+  FlowNodeInstanceState,
   ICorrelationService,
   IFlowNodeInstanceService,
   IProcessModelUseCases,
@@ -15,6 +16,10 @@ import {IProcessModelFacade, IProcessModelFacadeFactory} from '@process-engine/p
 import {applyPagination} from './paginator';
 import * as ProcessModelCache from './process_model_cache';
 
+const superAdminClaim = 'can_manage_process_instances';
+const canTriggerMessagesClaim = 'can_trigger_messages';
+const canTriggerSignalsClaim = 'can_trigger_signals';
+
 export class EventService implements APIs.IEventConsumerApi {
 
   private readonly correlationService: ICorrelationService;
@@ -23,9 +28,6 @@ export class EventService implements APIs.IEventConsumerApi {
   private readonly iamService: IIAMService;
   private readonly processModelUseCase: IProcessModelUseCases;
   private readonly processModelFacadeFactory: IProcessModelFacadeFactory;
-
-  private readonly canTriggerMessagesClaim = 'can_trigger_messages';
-  private readonly canTriggerSignalsClaim = 'can_trigger_signals';
 
   constructor(
     correlationService: ICorrelationService,
@@ -52,11 +54,7 @@ export class EventService implements APIs.IEventConsumerApi {
 
     const suspendedFlowNodeInstances = await this.flowNodeInstanceService.querySuspendedByProcessModel(processModelId);
 
-    const suspendedEvents = suspendedFlowNodeInstances.filter(this.isFlowNodeAnEvent);
-
-    const eventList = await this.convertFlowNodeInstancesToEvents(identity, suspendedEvents);
-
-    eventList.events = applyPagination(eventList.events, offset, limit);
+    const eventList = await this.filterAndConvertEventList(identity, suspendedFlowNodeInstances, offset, limit);
 
     return eventList;
   }
@@ -70,22 +68,7 @@ export class EventService implements APIs.IEventConsumerApi {
 
     const suspendedFlowNodeInstances = await this.flowNodeInstanceService.querySuspendedByCorrelation(correlationId);
 
-    const suspendedEvents = suspendedFlowNodeInstances.filter(this.isFlowNodeAnEvent);
-
-    const accessibleEvents = await Promise.filter(suspendedEvents, async (flowNode: FlowNodeInstance): Promise<boolean> => {
-      try {
-        await this.processModelUseCase.getProcessModelById(identity, flowNode.processModelId);
-
-        return true;
-      } catch (error) {
-
-        return false;
-      }
-    });
-
-    const eventList = await this.convertFlowNodeInstancesToEvents(identity, accessibleEvents);
-
-    eventList.events = applyPagination(eventList.events, offset, limit);
+    const eventList = await this.filterAndConvertEventList(identity, suspendedFlowNodeInstances, offset, limit);
 
     return eventList;
   }
@@ -98,26 +81,20 @@ export class EventService implements APIs.IEventConsumerApi {
     limit: number = 0,
   ): Promise<DataModels.Events.EventList> {
 
-    const suspendedFlowNodeInstances = await this.flowNodeInstanceService.querySuspendedByCorrelation(correlationId);
+    const flowNodeInstances = await this.flowNodeInstanceService.queryByCorrelationAndProcessModel(correlationId, processModelId);
 
-    const suspendedEvents = suspendedFlowNodeInstances.filter((flowNode: FlowNodeInstance): boolean => {
-
-      const flowNodeIsEvent = this.isFlowNodeAnEvent(flowNode);
-      const flowNodeBelongsToProcessModel = flowNode.processModelId === processModelId;
-
-      return flowNodeIsEvent && flowNodeBelongsToProcessModel;
+    const suspendedFlowNodeInstances = flowNodeInstances.filter((flowNodeInstance: FlowNodeInstance): boolean => {
+      return flowNodeInstance.state === FlowNodeInstanceState.suspended;
     });
 
-    const eventList = await this.convertFlowNodeInstancesToEvents(identity, suspendedEvents);
-
-    eventList.events = applyPagination(eventList.events, offset, limit);
+    const eventList = await this.filterAndConvertEventList(identity, suspendedFlowNodeInstances, offset, limit);
 
     return eventList;
   }
 
   public async triggerMessageEvent(identity: IIdentity, messageName: string, payload?: DataModels.Events.EventTriggerPayload): Promise<void> {
 
-    await this.iamService.ensureHasClaim(identity, this.canTriggerMessagesClaim);
+    await this.iamService.ensureHasClaim(identity, canTriggerMessagesClaim);
 
     const messageEventName = Messages.EventAggregatorSettings.messagePaths.messageEventReached
       .replace(Messages.EventAggregatorSettings.messageParams.messageReference, messageName);
@@ -127,12 +104,75 @@ export class EventService implements APIs.IEventConsumerApi {
 
   public async triggerSignalEvent(identity: IIdentity, signalName: string, payload?: DataModels.Events.EventTriggerPayload): Promise<void> {
 
-    await this.iamService.ensureHasClaim(identity, this.canTriggerSignalsClaim);
+    await this.iamService.ensureHasClaim(identity, canTriggerSignalsClaim);
 
     const signalEventName = Messages.EventAggregatorSettings.messagePaths.signalEventReached
       .replace(Messages.EventAggregatorSettings.messageParams.signalReference, signalName);
 
     this.eventAggregator.publish(signalEventName, payload);
+  }
+
+  public async filterAndConvertEventList(
+    identity: IIdentity,
+    suspendedFlowNodes: Array<FlowNodeInstance>,
+    offset?: number,
+    limit?: number,
+  ): Promise<DataModels.Events.EventList> {
+
+    const events = suspendedFlowNodes.filter(this.checkIfFlowNodeIsAnEvent);
+
+    const accessibleEvents = await this.filterInacessibleFlowNodeInstances(identity, events);
+
+    const eventsToReturn = applyPagination(accessibleEvents, offset, limit);
+
+    const eventList = await this.convertFlowNodeInstancesToEvents(identity, eventsToReturn);
+
+    return eventList;
+  }
+
+  private checkIfFlowNodeIsAnEvent(flowNodeInstance: FlowNodeInstance): boolean {
+    return flowNodeInstance.eventType !== undefined;
+  }
+
+  private async filterInacessibleFlowNodeInstances(
+    identity: IIdentity,
+    flowNodeInstances: Array<FlowNodeInstance>,
+  ): Promise<Array<FlowNodeInstance>> {
+    const isSuperAdmin = await this.checkIfUserIsSuperAdmin(identity);
+
+    if (isSuperAdmin) {
+      return flowNodeInstances;
+    }
+
+    const accessibleFlowNodeInstances = Promise.filter(flowNodeInstances, async (item: FlowNodeInstance): Promise<boolean> => {
+      return this.checkIfUserCanAccessFlowNodeInstance(identity, item);
+    });
+
+    return accessibleFlowNodeInstances;
+  }
+
+  private async checkIfUserCanAccessFlowNodeInstance(identity: IIdentity, flowNodeInstance: FlowNodeInstance): Promise<boolean> {
+    try {
+      if (!flowNodeInstance.flowNodeLane) {
+        return true;
+      }
+
+      await this.iamService.ensureHasClaim(identity, flowNodeInstance.flowNodeLane);
+
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  private async checkIfUserIsSuperAdmin(identity: IIdentity): Promise<boolean> {
+    try {
+      await this.iamService.ensureHasClaim(identity, superAdminClaim);
+
+      return true;
+    } catch (error) {
+      return false;
+    }
   }
 
   private async convertFlowNodeInstancesToEvents(
@@ -151,10 +191,6 @@ export class EventService implements APIs.IEventConsumerApi {
     };
 
     return eventList;
-  }
-
-  private isFlowNodeAnEvent(flowNodeInstance: FlowNodeInstance): boolean {
-    return flowNodeInstance.eventType !== undefined;
   }
 
   private async convertToConsumerApiEvent(identity: IIdentity, suspendedFlowNode: FlowNodeInstance): Promise<DataModels.Events.Event> {

--- a/src/flow_node_instance_service.ts
+++ b/src/flow_node_instance_service.ts
@@ -1,6 +1,5 @@
 import {APIs, DataModels} from '@process-engine/consumer_api_contracts';
 import {
-  BpmnType,
   FlowNodeInstance,
   FlowNodeInstanceState,
   IFlowNodeInstanceService,
@@ -140,15 +139,14 @@ export class FlowNodeInstanceService implements APIs.IFlowNodeInstanceConsumerAp
     return taskList;
   }
 
-  private async convertFlowNodeInstancesToTaskList(identity: IIdentity, suspendedFlowNodes: Array<FlowNodeInstance>): Promise<Array<Task>> {
+  private async convertFlowNodeInstancesToTaskList(
+    identity: IIdentity,
+    suspendedFlowNodes: Array<FlowNodeInstance>,
+  ): Promise<Array<Task>> {
 
-    const suspendedEmptyActivities = suspendedFlowNodes.filter((flowNode): boolean => flowNode.flowNodeType === BpmnType.emptyActivity);
-    const suspendedManualTasks = suspendedFlowNodes.filter((flowNode): boolean => flowNode.flowNodeType === BpmnType.manualTask);
-    const suspendedUserTasks = suspendedFlowNodes.filter((flowNode): boolean => flowNode.flowNodeType === BpmnType.userTask);
-
-    const emptyActivityList = await this.emptyActivityService.convertFlowNodeInstancesToEmptyActivities(identity, suspendedEmptyActivities);
-    const manualTaskList = await this.manualTaskService.convertFlowNodeInstancesToManualTasks(identity, suspendedManualTasks);
-    const userTaskList = await this.userTaskService.convertFlowNodeInstancesToUserTasks(identity, suspendedUserTasks);
+    const emptyActivityList = await this.emptyActivityService.filterAndConvertEmptyActivityList(identity, suspendedFlowNodes);
+    const manualTaskList = await this.manualTaskService.filterAndConvertManualTaskList(identity, suspendedFlowNodes);
+    const userTaskList = await this.userTaskService.filterAndConvertUserTaskList(identity, suspendedFlowNodes);
 
     const tasks = [...emptyActivityList.emptyActivities, ...manualTaskList.manualTasks, ...userTaskList.userTasks];
 

--- a/src/manual_task_service.ts
+++ b/src/manual_task_service.ts
@@ -6,50 +6,34 @@ import {
   BpmnType,
   FlowNodeInstance,
   FlowNodeInstanceState,
-  ICorrelationService,
   IFlowNodeInstanceService,
-  IProcessModelUseCases,
-  Model,
   ProcessTokenType,
 } from '@process-engine/persistence_api.contracts';
-import {
-  IProcessModelFacade,
-  IProcessModelFacadeFactory,
-  FinishManualTaskMessage as InternalFinishManualTaskMessage,
-} from '@process-engine/process_engine_contracts';
+import {FinishManualTaskMessage as InternalFinishManualTaskMessage} from '@process-engine/process_engine_contracts';
 
 import {NotificationAdapter} from './adapters/index';
 import {applyPagination} from './paginator';
-import * as ProcessModelCache from './process_model_cache';
+
+const superAdminClaim = 'can_manage_process_instances';
+const canSubscribeToEventsClaim = 'can_subscribe_to_events';
 
 export class ManualTaskService implements APIs.IManualTaskConsumerApi {
 
-  private readonly correlationService: ICorrelationService;
   private readonly eventAggregator: IEventAggregator;
   private readonly flowNodeInstanceService: IFlowNodeInstanceService;
   private readonly iamService: IIAMService;
   private readonly notificationAdapter: NotificationAdapter;
-  private readonly processModelUseCase: IProcessModelUseCases;
-  private readonly processModelFacadeFactory: IProcessModelFacadeFactory;
-
-  private readonly canSubscribeToEventsClaim = 'can_subscribe_to_events';
 
   constructor(
-    correlationService: ICorrelationService,
     eventAggregator: IEventAggregator,
     flowNodeInstanceService: IFlowNodeInstanceService,
     iamService: IIAMService,
     notificationAdapter: NotificationAdapter,
-    processModelFacadeFactory: IProcessModelFacadeFactory,
-    processModelUseCase: IProcessModelUseCases,
   ) {
-    this.correlationService = correlationService;
     this.eventAggregator = eventAggregator;
     this.flowNodeInstanceService = flowNodeInstanceService;
     this.iamService = iamService;
     this.notificationAdapter = notificationAdapter;
-    this.processModelFacadeFactory = processModelFacadeFactory;
-    this.processModelUseCase = processModelUseCase;
 
   }
 
@@ -58,7 +42,7 @@ export class ManualTaskService implements APIs.IManualTaskConsumerApi {
     callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
     subscribeOnce = false,
   ): Promise<Subscription> {
-    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+    await this.iamService.ensureHasClaim(identity, canSubscribeToEventsClaim);
 
     return this.notificationAdapter.onManualTaskWaiting(identity, callback, subscribeOnce);
   }
@@ -68,7 +52,7 @@ export class ManualTaskService implements APIs.IManualTaskConsumerApi {
     callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
     subscribeOnce = false,
   ): Promise<Subscription> {
-    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+    await this.iamService.ensureHasClaim(identity, canSubscribeToEventsClaim);
 
     return this.notificationAdapter.onManualTaskFinished(identity, callback, subscribeOnce);
   }
@@ -78,7 +62,7 @@ export class ManualTaskService implements APIs.IManualTaskConsumerApi {
     callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
     subscribeOnce = false,
   ): Promise<Subscription> {
-    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+    await this.iamService.ensureHasClaim(identity, canSubscribeToEventsClaim);
 
     return this.notificationAdapter.onManualTaskForIdentityWaiting(identity, callback, subscribeOnce);
   }
@@ -88,7 +72,7 @@ export class ManualTaskService implements APIs.IManualTaskConsumerApi {
     callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
     subscribeOnce = false,
   ): Promise<Subscription> {
-    await this.iamService.ensureHasClaim(identity, this.canSubscribeToEventsClaim);
+    await this.iamService.ensureHasClaim(identity, canSubscribeToEventsClaim);
 
     return this.notificationAdapter.onManualTaskForIdentityFinished(identity, callback, subscribeOnce);
   }
@@ -102,11 +86,7 @@ export class ManualTaskService implements APIs.IManualTaskConsumerApi {
 
     const suspendedFlowNodes = await this.flowNodeInstanceService.querySuspendedByProcessModel(processModelId);
 
-    const manualTasks = suspendedFlowNodes.filter(this.checkIfIsFlowNodeIsManualTask);
-
-    const manualTaskList = await this.convertFlowNodeInstancesToManualTasks(identity, manualTasks);
-
-    manualTaskList.manualTasks = applyPagination(manualTaskList.manualTasks, offset, limit);
+    const manualTaskList = await this.filterAndConvertManualTaskList(identity, suspendedFlowNodes, offset, limit);
 
     return manualTaskList;
   }
@@ -120,11 +100,7 @@ export class ManualTaskService implements APIs.IManualTaskConsumerApi {
 
     const suspendedFlowNodes = await this.flowNodeInstanceService.querySuspendedByProcessInstance(processInstanceId);
 
-    const manualTasks = suspendedFlowNodes.filter(this.checkIfIsFlowNodeIsManualTask);
-
-    const manualTaskList = await this.convertFlowNodeInstancesToManualTasks(identity, manualTasks);
-
-    manualTaskList.manualTasks = applyPagination(manualTaskList.manualTasks, offset, limit);
+    const manualTaskList = await this.filterAndConvertManualTaskList(identity, suspendedFlowNodes, offset, limit);
 
     return manualTaskList;
   }
@@ -138,11 +114,7 @@ export class ManualTaskService implements APIs.IManualTaskConsumerApi {
 
     const suspendedFlowNodes = await this.flowNodeInstanceService.querySuspendedByCorrelation(correlationId);
 
-    const manualTasks = suspendedFlowNodes.filter(this.checkIfIsFlowNodeIsManualTask);
-
-    const manualTaskList = await this.convertFlowNodeInstancesToManualTasks(identity, manualTasks);
-
-    manualTaskList.manualTasks = applyPagination(manualTaskList.manualTasks, offset, limit);
+    const manualTaskList = await this.filterAndConvertManualTaskList(identity, suspendedFlowNodes, offset, limit);
 
     return manualTaskList;
   }
@@ -155,17 +127,13 @@ export class ManualTaskService implements APIs.IManualTaskConsumerApi {
     limit: number = 0,
   ): Promise<DataModels.ManualTasks.ManualTaskList> {
 
-    const suspendedFlowNodes = await this.flowNodeInstanceService.querySuspendedByCorrelation(correlationId);
+    const flowNodeInstances = await this.flowNodeInstanceService.queryByCorrelationAndProcessModel(correlationId, processModelId);
 
-    const suspendedFlowNodeInstances = suspendedFlowNodes.filter((flowNodeInstance: FlowNodeInstance): boolean => {
-      const isManualTask = this.checkIfIsFlowNodeIsManualTask(flowNodeInstance);
-      const belongsToProcessModel = flowNodeInstance.processModelId === processModelId;
-      return isManualTask && belongsToProcessModel;
+    const suspendedFlowNodes = flowNodeInstances.filter((flowNodeInstance: FlowNodeInstance): boolean => {
+      return flowNodeInstance.state === FlowNodeInstanceState.suspended;
     });
 
-    const manualTaskList = await this.convertFlowNodeInstancesToManualTasks(identity, suspendedFlowNodeInstances);
-
-    manualTaskList.manualTasks = applyPagination(manualTaskList.manualTasks, offset, limit);
+    const manualTaskList = await this.filterAndConvertManualTaskList(identity, suspendedFlowNodes, offset, limit);
 
     return manualTaskList;
   }
@@ -184,9 +152,9 @@ export class ManualTaskService implements APIs.IManualTaskConsumerApi {
       return isManualTask && userIdsMatch;
     });
 
-    const manualTaskList = await this.convertFlowNodeInstancesToManualTasks(identity, flowNodeInstancesOwnedByUser);
+    const manualTasksToReturn = applyPagination(flowNodeInstancesOwnedByUser, offset, limit);
 
-    manualTaskList.manualTasks = applyPagination(manualTaskList.manualTasks, offset, limit);
+    const manualTaskList = this.convertFlowNodeInstancesToManualTasks(manualTasksToReturn);
 
     return manualTaskList;
   }
@@ -201,16 +169,15 @@ export class ManualTaskService implements APIs.IManualTaskConsumerApi {
     const matchingFlowNodeInstance =
       await this.getFlowNodeInstanceForCorrelationInProcessInstance(correlationId, processInstanceId, manualTaskInstanceId);
 
-    const noMatchingInstanceFound = matchingFlowNodeInstance === undefined;
-    if (noMatchingInstanceFound) {
+    if (matchingFlowNodeInstance === undefined) {
       const errorMessage =
         `ProcessInstance '${processInstanceId}' in Correlation '${correlationId}' does not have a ManualTask with id '${manualTaskInstanceId}'`;
       throw new EssentialProjectErrors.NotFoundError(errorMessage);
     }
 
-    const convertedUserTaskList = await this.convertFlowNodeInstancesToManualTasks(identity, [matchingFlowNodeInstance]);
-
-    const matchingManualTask = convertedUserTaskList.manualTasks[0];
+    if (matchingFlowNodeInstance.flowNodeLane !== undefined) {
+      await this.ensureHasClaim(identity, matchingFlowNodeInstance.flowNodeLane);
+    }
 
     return new Promise<void>((resolve: Function): void => {
       const routePrameter: {[name: string]: string} = Messages.EventAggregatorSettings.messageParams;
@@ -225,19 +192,31 @@ export class ManualTaskService implements APIs.IManualTaskConsumerApi {
         resolve();
       });
 
-      this.publishFinishManualTaskEvent(identity, matchingManualTask);
+      this.publishFinishManualTaskEvent(identity, matchingFlowNodeInstance);
     });
   }
 
-  public async convertFlowNodeInstancesToManualTasks(
+  public async filterAndConvertManualTaskList(
     identity: IIdentity,
     suspendedFlowNodes: Array<FlowNodeInstance>,
+    offset?: number,
+    limit?: number,
   ): Promise<DataModels.ManualTasks.ManualTaskList> {
 
-    const suspendedManualTasks =
-      await Promise.map(suspendedFlowNodes, async (suspendedFlowNode): Promise<DataModels.ManualTasks.ManualTask> => {
-        return this.convertSuspendedFlowNodeToManualTask(identity, suspendedFlowNode);
-      });
+    const manualTasks = suspendedFlowNodes.filter(this.checkIfIsFlowNodeIsManualTask);
+
+    const accessibleManualTasks = await this.filterInacessibleFlowNodeInstances(identity, manualTasks);
+
+    const manualTasksToReturn = applyPagination(accessibleManualTasks, offset, limit);
+
+    const manualTaskList = this.convertFlowNodeInstancesToManualTasks(manualTasksToReturn);
+
+    return manualTaskList;
+  }
+
+  private convertFlowNodeInstancesToManualTasks(suspendedFlowNodes: Array<FlowNodeInstance>): DataModels.ManualTasks.ManualTaskList {
+
+    const suspendedManualTasks = suspendedFlowNodes.map(this.convertSuspendedFlowNodeToManualTask);
 
     const manualTaskList: DataModels.ManualTasks.ManualTaskList = {
       manualTasks: suspendedManualTasks,
@@ -255,21 +234,66 @@ export class ManualTaskService implements APIs.IManualTaskConsumerApi {
     return identityA.userId === identityB.userId;
   }
 
-  private async convertSuspendedFlowNodeToManualTask(
+  private async filterInacessibleFlowNodeInstances(
     identity: IIdentity,
-    manualTaskInstance: FlowNodeInstance,
-  ): Promise<DataModels.ManualTasks.ManualTask> {
+    flowNodeInstances: Array<FlowNodeInstance>,
+  ): Promise<Array<FlowNodeInstance>> {
+    const isSuperAdmin = await this.checkIfUserIsSuperAdmin(identity);
+
+    if (isSuperAdmin) {
+      return flowNodeInstances;
+    }
+
+    const accessibleFlowNodeInstances = Promise.filter(flowNodeInstances, async (item: FlowNodeInstance): Promise<boolean> => {
+      return this.checkIfUserCanAccessFlowNodeInstance(identity, item);
+    });
+
+    return accessibleFlowNodeInstances;
+  }
+
+  private async checkIfUserCanAccessFlowNodeInstance(identity: IIdentity, flowNodeInstance: FlowNodeInstance): Promise<boolean> {
+    try {
+      if (!flowNodeInstance.flowNodeLane) {
+        return true;
+      }
+
+      await this.iamService.ensureHasClaim(identity, flowNodeInstance.flowNodeLane);
+
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  private async ensureHasClaim(identity: IIdentity, claimName: string): Promise<void> {
+    const isSuperAdmin = await this.checkIfUserIsSuperAdmin(identity);
+
+    if (isSuperAdmin) {
+      return;
+    }
+
+    await this.iamService.ensureHasClaim(identity, claimName);
+  }
+
+  private async checkIfUserIsSuperAdmin(identity: IIdentity): Promise<boolean> {
+    try {
+      await this.iamService.ensureHasClaim(identity, superAdminClaim);
+
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  private convertSuspendedFlowNodeToManualTask(manualTaskInstance: FlowNodeInstance): DataModels.ManualTasks.ManualTask {
 
     const onSuspendToken = manualTaskInstance.getTokenByType(ProcessTokenType.onSuspend);
-
-    const processModelFacade = await this.getProcessModelForFlowNodeInstance(identity, manualTaskInstance);
-    const manualTaskModel = processModelFacade.getFlowNodeById(manualTaskInstance.flowNodeId);
 
     const consumerApiManualTask: DataModels.ManualTasks.ManualTask = {
       flowNodeType: BpmnType.manualTask,
       id: manualTaskInstance.flowNodeId,
       flowNodeInstanceId: manualTaskInstance.id,
-      name: manualTaskModel.name,
+      name: manualTaskInstance.flowNodeName,
       correlationId: manualTaskInstance.correlationId,
       processModelId: manualTaskInstance.processModelId,
       processInstanceId: manualTaskInstance.processInstanceId,
@@ -277,38 +301,6 @@ export class ManualTaskService implements APIs.IManualTaskConsumerApi {
     };
 
     return consumerApiManualTask;
-
-  }
-
-  private async getProcessModelForFlowNodeInstance(
-    identity: IIdentity,
-    flowNodeInstance: FlowNodeInstance,
-  ): Promise<IProcessModelFacade> {
-
-    let processModel: Model.Process;
-
-    // We must store the ProcessModel for each user, to account for lane-restrictions.
-    // Some users may not be able to see some lanes that are visible to others.
-    const cacheKeyToUse = `${flowNodeInstance.processInstanceId}-${identity.userId}`;
-
-    const cacheHasMatchingEntry = ProcessModelCache.hasEntry(cacheKeyToUse);
-    if (cacheHasMatchingEntry) {
-      processModel = ProcessModelCache.get(cacheKeyToUse);
-    } else {
-      const processModelHash = await this.getProcessModelHashForProcessInstance(identity, flowNodeInstance.processInstanceId);
-      processModel = await this.processModelUseCase.getByHash(identity, flowNodeInstance.processModelId, processModelHash);
-      ProcessModelCache.add(cacheKeyToUse, processModel);
-    }
-
-    const processModelFacade = this.processModelFacadeFactory.create(processModel);
-
-    return processModelFacade;
-  }
-
-  private async getProcessModelHashForProcessInstance(identity: IIdentity, processInstanceId: string): Promise<string> {
-    const processInstance = await this.correlationService.getByProcessInstanceId(identity, processInstanceId);
-
-    return processInstance.hash;
   }
 
   private async getFlowNodeInstanceForCorrelationInProcessInstance(
@@ -327,10 +319,7 @@ export class ManualTaskService implements APIs.IManualTaskConsumerApi {
     return matchingInstance;
   }
 
-  private publishFinishManualTaskEvent(
-    identity: IIdentity,
-    manualTaskInstance: DataModels.ManualTasks.ManualTask,
-  ): void {
+  private publishFinishManualTaskEvent(identity: IIdentity, manualTaskInstance: FlowNodeInstance): void {
 
     // ManualTasks do not produce results.
     const emptyPayload = {};
@@ -339,7 +328,7 @@ export class ManualTaskService implements APIs.IManualTaskConsumerApi {
       manualTaskInstance.processModelId,
       manualTaskInstance.processInstanceId,
       manualTaskInstance.id,
-      manualTaskInstance.flowNodeInstanceId,
+      manualTaskInstance.id,
       identity,
       emptyPayload,
     );
@@ -347,7 +336,7 @@ export class ManualTaskService implements APIs.IManualTaskConsumerApi {
     const finishManualTaskEvent = Messages.EventAggregatorSettings.messagePaths.finishManualTask
       .replace(Messages.EventAggregatorSettings.messageParams.correlationId, manualTaskInstance.correlationId)
       .replace(Messages.EventAggregatorSettings.messageParams.processInstanceId, manualTaskInstance.processInstanceId)
-      .replace(Messages.EventAggregatorSettings.messageParams.flowNodeInstanceId, manualTaskInstance.flowNodeInstanceId);
+      .replace(Messages.EventAggregatorSettings.messageParams.flowNodeInstanceId, manualTaskInstance.id);
 
     this.eventAggregator.publish(finishManualTaskEvent, finishManualTaskMessage);
   }


### PR DESCRIPTION
## Changes

1. Use the value of `FlowNodeInstance.flowNodeLane` to perform claim checks for task accessibility 
    - Includes UserTasks, ManualTasks, Events and EmptyActivities
2. Perform task filtering and pagination prior to conversion
3. Remove retrieval of a tasks's ProcessModel from the ManualTaskService and EmptyActivityService
    - This was not entirely possible for the other services, because Events and UserTasks require a lot of information from their models that cannot be added to a FlowNodeInstance (the UserTask's FormField Configs, for example)
    - The services will benefit from increased performance, because they now only have to perform a fraction of the `getProcessModel` queries they did before
4. Account for `SuperAdmin` claim during all queries, which greatly reduces the number of claim checks performed, if the requesting user actually is a super admin
5. When a user is not allowed to see any suspended task, he will now receive an empty array, instead of a 403. 
    - This fixes a possible issue, where a user might get more information about existing tasks, than he is supposed to 
    - i.e.: 403 says "there is something there, I just can't see it"; an empty Array suggests "there is nothing there to see"

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/427

PR: #109

## How to test the changes

- Run various requests for retrieving ManualTasks, UserTasks, Events and/or EmptyActivities
- The more tasks you retrieve, the greater the performance boost you should be able to notice