### PR TITLE
🐛 Fix handling of customized ExternalTaskErrors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/consumer_api_core",
-  "version": "6.2.0-alpha.1",
+  "version": "6.3.0",
   "description": "the api-package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/process-engine/consumer_api#readme",
   "dependencies": {
     "@essential-projects/errors_ts": "^1.5.0",
-    "@process-engine/consumer_api_contracts": "^9.1.0",
+    "@process-engine/consumer_api_contracts": "feature~add_optional_message_to_bpmn_error_type",
     "@process-engine/persistence_api.contracts": "^1.1.0",
     "@process-engine/process_engine_contracts": "^46.0.0",
     "bluebird": "~3.5.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/process-engine/consumer_api#readme",
   "dependencies": {
     "@essential-projects/errors_ts": "^1.5.0",
-    "@process-engine/consumer_api_contracts": "feature~add_optional_message_to_bpmn_error_type",
+    "@process-engine/consumer_api_contracts": "9.2.0-alpha.1",
     "@process-engine/persistence_api.contracts": "^1.1.0",
     "@process-engine/process_engine_contracts": "^46.0.0",
     "bluebird": "~3.5.2",

--- a/src/external_task_service.ts
+++ b/src/external_task_service.ts
@@ -63,14 +63,20 @@ export class ExternalTaskService implements APIs.IExternalTaskConsumerApi {
     return this.externalTaskService.lockForWorker(identity, workerId, externalTaskId, newLockExpirationTime);
   }
 
-  public async handleBpmnError(identity: IIdentity, workerId: string, externalTaskId: string, errorCode: string): Promise<void> {
+  public async handleBpmnError(
+    identity: IIdentity,
+    workerId: string,
+    externalTaskId: string,
+    errorCode: string,
+    errorMessage?: string,
+  ): Promise<void> {
 
     // Note: The type of the initial payload is irrelevant for finishing with an error.
     const externalTask = await this.externalTaskService.getById(identity, externalTaskId);
 
     this.ensureExternalTaskCanBeAccessedByWorker(externalTask, externalTaskId, workerId);
 
-    const error = new EssentialProjectErrors.InternalServerError(`ExternalTask failed due to BPMN error with code ${errorCode}`);
+    const error = new DataModels.ExternalTask.BpmnError('BpmnError', errorCode, errorMessage);
 
     await this.externalTaskService.finishWithError(identity, externalTaskId, error);
 
@@ -85,14 +91,14 @@ export class ExternalTaskService implements APIs.IExternalTaskConsumerApi {
     externalTaskId: string,
     errorMessage: string,
     errorDetails: string,
+    errorCode?: string,
   ): Promise<void> {
 
     const externalTask = await this.externalTaskService.getById(identity, externalTaskId);
 
     this.ensureExternalTaskCanBeAccessedByWorker(externalTask, externalTaskId, workerId);
 
-    const error = new EssentialProjectErrors.InternalServerError(errorMessage);
-    error.additionalInformation = errorDetails;
+    const error = new DataModels.ExternalTask.ServiceError('ServiceError', errorCode, errorMessage, errorDetails);
 
     await this.externalTaskService.finishWithError(identity, externalTaskId, error);
 


### PR DESCRIPTION
## Changes

1. Use internal serializable types for passing on ServiceErrors and BpmnErrors to the ProcessEngine

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/493

PR: #111

## How to test the changes

- Run a Process that uses ExternalTasks with ErrorBoundaryEvents
- Provoke an error that can be intercepted by the BoundaryEvent
- See that it works