### PR TITLE
✨ Add route for retrieving informtion about the host application

### DIFF
--- a/ioc_module.js
+++ b/ioc_module.js
@@ -1,4 +1,5 @@
 const {
+  ApplicationInfoService,
   NotificationAdapter,
   EmptyActivityService,
   EventService,
@@ -11,6 +12,10 @@ const {
 } = require('./dist/commonjs/index');
 
 function registerInContainer(container) {
+
+  container
+    .register('ConsumerApiApplicationInfoService', ApplicationInfoService)
+    .singleton();
 
   container
     .register('ConsumerApiNotificationAdapter', NotificationAdapter)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/process-engine/consumer_api#readme",
   "dependencies": {
     "@essential-projects/errors_ts": "^1.5.0",
-    "@process-engine/consumer_api_contracts": "feature~add_info_route",
+    "@process-engine/consumer_api_contracts": "10.0.0-alpha.2",
     "@process-engine/persistence_api.contracts": "^1.1.0",
     "@process-engine/process_engine_contracts": "^47.0.0",
     "app-root-path": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/process-engine/consumer_api#readme",
   "dependencies": {
     "@essential-projects/errors_ts": "^1.5.0",
-    "@process-engine/consumer_api_contracts": "^9.2.0",
+    "@process-engine/consumer_api_contracts": "feature~add_info_route",
     "@process-engine/persistence_api.contracts": "^1.1.0",
     "@process-engine/process_engine_contracts": "^47.0.0",
     "bluebird": "~3.5.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@process-engine/consumer_api_contracts": "feature~add_info_route",
     "@process-engine/persistence_api.contracts": "^1.1.0",
     "@process-engine/process_engine_contracts": "^47.0.0",
+    "app-root-path": "^3.0.0",
     "bluebird": "^3.7.2",
     "bluebird-global": "~1.0.1",
     "loggerhythm": "~3.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/consumer_api_core",
-  "version": "6.3.2",
+  "version": "6.4.0",
   "description": "the api-package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@process-engine/consumer_api_contracts": "feature~add_info_route",
     "@process-engine/persistence_api.contracts": "^1.1.0",
     "@process-engine/process_engine_contracts": "^47.0.0",
-    "bluebird": "~3.5.2",
+    "bluebird": "^3.7.2",
     "bluebird-global": "~1.0.1",
     "loggerhythm": "~3.0.3",
     "node-uuid": "~1.4.8"

--- a/src/application_info_service.ts
+++ b/src/application_info_service.ts
@@ -1,0 +1,60 @@
+import * as appRootPath from 'app-root-path';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {APIs, DataModels} from '@process-engine/consumer_api_contracts';
+
+export class ApplicationInfoService implements APIs.IApplicationInfoConsumerApi {
+
+  private applicationInfo: DataModels.ApplicationInfo;
+
+  public async getApplicationInfo(): Promise<DataModels.ApplicationInfo> {
+    if (!this.applicationInfo) {
+      this.readApplicationPackageJson();
+    }
+
+    return this.applicationInfo;
+  }
+
+  private readApplicationPackageJson(): void {
+    const isEmbeddedIntoRuntime = __dirname.indexOf('process_engine_runtime') > 0;
+
+    const pathToPackageJson = isEmbeddedIntoRuntime
+      ? this.getPackageJsonLocationForProcessEngineRuntime()
+      : this.getPackageJsonLocationForHostApplication();
+
+    const packageJson = this.getPackageJsonContent(pathToPackageJson);
+
+    this.applicationInfo = {
+      name: packageJson.name,
+      version: packageJson.version,
+    };
+  }
+
+  private getPackageJsonLocationForProcessEngineRuntime(): string {
+    // Note that if the Runtime is embedded into another application, the runtime's package.json will not be the main package.json,
+    // It will instead be located in `someapplication/node_modules/@process-engine/process_engine-runtime`.
+    // Therefore, we cannot use app-root-path here.
+    const pathToRuntime = __dirname.split('process_engine_runtime')[0];
+    const pathToPackageJson = path.resolve(pathToRuntime, 'process_engine_runtime', 'package.json');
+
+    return pathToPackageJson;
+  }
+
+  private getPackageJsonLocationForHostApplication(): string {
+    // When running this from inside other applications than the runtime (like consumer_api_meta),
+    // we'll get the package info for the host application.
+    const rootPath = appRootPath.toString();
+    const pathToPackageJson = path.resolve(rootPath, 'package.json');
+
+    return pathToPackageJson;
+  }
+
+  private getPackageJsonContent(pathToPackageJson: string): any {
+    const packageJsonAsString = fs.readFileSync(pathToPackageJson, 'utf-8');
+    const packageJson = JSON.parse(packageJsonAsString);
+
+    return packageJson;
+  }
+
+}

--- a/src/application_info_service.ts
+++ b/src/application_info_service.ts
@@ -35,7 +35,8 @@ export class ApplicationInfoService implements APIs.IApplicationInfoConsumerApi 
     // Note that if the Runtime is embedded into another application, the runtime's package.json will not be the main package.json,
     // It will instead be located in `someapplication/node_modules/@process-engine/process_engine-runtime`.
     // Therefore, we cannot use app-root-path here.
-    const pathToRuntime = __dirname.split('process_engine_runtime')[0];
+    const applicationFolderIndex = __dirname.lastIndexOf('process_engine_runtime');
+    const pathToRuntime = __dirname.substring(0, applicationFolderIndex);
     const pathToPackageJson = path.resolve(pathToRuntime, 'process_engine_runtime', 'package.json');
 
     return pathToPackageJson;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './adapters/index';
 
+export * from './application_info_service';
 export * from './empty_activity_service';
 export * from './event_service';
 export * from './external_task_service';


### PR DESCRIPTION
## Changes

Implement `getApplicationInfo` UseCase. Works for a standalone- or embedded- `ProcessEngineRuntime`s, as well as applications other than the ProcessEngineRuntime

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/531

PR: #112

## How to test the changes

- Call the service method
- See that it returns information about the hosting application, regardless of whether it is a `ProcessEngineRuntime` or not