### PR TITLE
♻️ Avoid unnecessary not found errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/consumer_api_core",
-  "version": "6.4.1",
+  "version": "6.5.0",
   "description": "the api-package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
## Changes

`getProcessResultForCorrelation` now returns an empty Array, if no results were found.

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/550

PR: #114

## How to test the changes

- Run requests for retrieving the results for a non-existing Process Model or Correlation
- Get an empty array, instead of a 404 error